### PR TITLE
Add support for nested_type field in tjson Converter

### DIFF
--- a/pkg/types/conversion/tfjson/tfjson.go
+++ b/pkg/types/conversion/tfjson/tfjson.go
@@ -95,7 +95,7 @@ func tfJSONAttributeToV2Schema(attr *tfjson.SchemaAttribute) *schemav2.Schema {
 		}
 		return v2sch
 	}
-	panic("attribute neither has \"type\" nor \"nested-type\" defined")
+	panic(`attribute neither has "type" nor "nested-type" defined`)
 }
 
 func tfJSONBlockTypeToV2Schema(nb *tfjson.SchemaBlockType) *schemav2.Schema { //nolint:gocyclo
@@ -157,6 +157,8 @@ func tfJSONBlockTypeToV2Schema(nb *tfjson.SchemaBlockType) *schemav2.Schema { //
 }
 
 func schemaV2TypeFromNestedType(ntyp *tfjson.SchemaNestedAttributeType, schema *schemav2.Schema) error {
+	// Note(turkenh): See the comments for SchemaNestingModes in tfjson code:
+	// https://github.com/hashicorp/terraform-json/blob/e6b203c3cb12469bcf829be00d16379c595008ed/schemas.go#L131
 	switch ntyp.NestingMode {
 	case tfjson.SchemaNestingModeSingle:
 		schema.Type = schemav2.TypeList
@@ -173,7 +175,7 @@ func schemaV2TypeFromNestedType(ntyp *tfjson.SchemaNestedAttributeType, schema *
 	case tfjson.SchemaNestingModeMap:
 		schema.Type = schemav2.TypeMap
 	default:
-		return errors.Errorf("unknown nesting mode: %s", ntyp.NestingMode)
+		return errors.Errorf("unknown nesting mode: %q", ntyp.NestingMode)
 	}
 
 	res := &schemav2.Resource{}


### PR DESCRIPTION
### Description of your changes

It looks like we never had a provider schema using `nested_type` field instead if using `type` field for a collection type.
This PR fixes #121 by adding support for `nested_type` in tfjson converter code that we are using to convert tfjson schema to sdk v2 schema.

Fixes #121 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

I could successfully generate all resources using the schema provided in #121.
I have also verified that consuming this change does not cause any difference in the generated schema for `upbound/provider-aws`,` upbound/provider-gcp` and `upbound/provider-azure` to make sure that we are not breaking something there.
