### PR TITLE
Add config.Provider.GetSkippedResourceNames

### DIFF
--- a/pkg/config/provider.go
+++ b/pkg/config/provider.go
@@ -85,6 +85,12 @@ type Provider struct {
 	// can add "aws_waf.*" to the list.
 	SkipList []string
 
+	// skippedResourceNames is a list of Terraform resource names
+	// available in the Terraform provider schema, but
+	// not in the include list or in the skip list, meaning that
+	// the corresponding managed resources are not generated.
+	skippedResourceNames []string
+
 	// IncludeList is a list of regex for the Terraform resources to be
 	// included. For example, to include "aws_shield_protection_group" into
 	// the generated resources, one can add "aws_shield_protection_group$".
@@ -207,7 +213,9 @@ func NewProvider(schema []byte, prefix string, modulePath string, metadata []byt
 		o(p)
 	}
 
+	p.skippedResourceNames = make([]string, 0, len(resourceMap))
 	for name, terraformResource := range resourceMap {
+		p.skippedResourceNames = append(p.skippedResourceNames, name)
 		if len(terraformResource.Schema) == 0 {
 			// There are resources with no schema, that we will address later.
 			fmt.Printf("Skipping resource %s because it has no schema\n", name)
@@ -219,7 +227,8 @@ func NewProvider(schema []byte, prefix string, modulePath string, metadata []byt
 		if !matches(name, p.IncludeList) {
 			continue
 		}
-
+		// resource is to be generated, so remove it from the skipped list
+		p.skippedResourceNames = p.skippedResourceNames[:len(p.skippedResourceNames)-1]
 		p.Resources[name] = DefaultResource(name, terraformResource, providerMetadata.Resources[name], p.DefaultResourceOptions...)
 	}
 	for i, refInjector := range p.refInjectors {
@@ -253,6 +262,14 @@ func (p *Provider) ConfigureResources() {
 			c.Configure(r)
 		}
 	}
+}
+
+// GetSkippedResourceNames returns a list of Terraform resource names
+// available in the Terraform provider schema, but
+// not in the include list or in the skip list, meaning that
+// the corresponding managed resources are not generated.
+func (p *Provider) GetSkippedResourceNames() []string {
+	return p.skippedResourceNames
 }
 
 func matches(name string, regexList []string) bool {

--- a/pkg/config/provider.go
+++ b/pkg/config/provider.go
@@ -215,20 +215,14 @@ func NewProvider(schema []byte, prefix string, modulePath string, metadata []byt
 
 	p.skippedResourceNames = make([]string, 0, len(resourceMap))
 	for name, terraformResource := range resourceMap {
-		p.skippedResourceNames = append(p.skippedResourceNames, name)
 		if len(terraformResource.Schema) == 0 {
 			// There are resources with no schema, that we will address later.
 			fmt.Printf("Skipping resource %s because it has no schema\n", name)
+		}
+		if len(terraformResource.Schema) == 0 || matches(name, p.SkipList) || !matches(name, p.IncludeList) {
+			p.skippedResourceNames = append(p.skippedResourceNames, name)
 			continue
 		}
-		if matches(name, p.SkipList) {
-			continue
-		}
-		if !matches(name, p.IncludeList) {
-			continue
-		}
-		// resource is to be generated, so remove it from the skipped list
-		p.skippedResourceNames = p.skippedResourceNames[:len(p.skippedResourceNames)-1]
 		p.Resources[name] = DefaultResource(name, terraformResource, providerMetadata.Resources[name], p.DefaultResourceOptions...)
 	}
 	for i, refInjector := range p.refInjectors {


### PR DESCRIPTION
<!--
Thank you for helping to improve Upjet!

Please read through https://git.io/fj2m9 if this is your first time opening a
Upjet pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Upjet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This PR proposes to add a `config.Provider.GetSkippedResourceNames` method that returns a list of Terraform resource names that are available in the Terraform provider schema but that are either skipped or not included so that they are not generated as managed resources.

I've also considered:
- Directly generating the diff file when a path is configured (via provider configuration). But generating this diff, in my opinion, would be a supporting function (not among the core code generation pipelines), so instead of configuring a file path to store the diff and having Upjet generate it, I preferred a change to make Upjet be able to directly supply the required diff information
- Another approach would be not to touch Upjet but instead do the diff calculation in the providers themselves. In the provider, we already have the JSON schema from which we can extract the set of Terraform resources available and also the names of the Terraform resources for which we have generated the corresponding MRs (in the generated files under `apis`). But I found this approach too indirect and requiring further processing for a directly available piece of information. Thus I went with the small change proposed in this PR.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Tested against upbound/provider-aws.

[contribution process]: https://git.io/fj2m9
