### PR TITLE
Handle sensitive input maps via SecretReference

### DIFF
--- a/pkg/resource/sensitive.go
+++ b/pkg/resource/sensitive.go
@@ -217,7 +217,10 @@ func GetSensitiveParameters(ctx context.Context, client SecretClient, from runti
 						return errors.Wrapf(err, errFmtCannotGetSecretKeySelectorAsMap, expandedJSONPath)
 					}
 					data, err := client.GetSecretData(ctx, ref)
-					if err != nil {
+					// We don't want to fail if the secret is not found. Otherwise, we won't be able to delete the
+					// resource if secret is deleted before. This is quite expected when both secret and resource
+					// got deleted in parallel.
+					if resource.IgnoreNotFound(err) != nil {
 						return errors.Wrapf(err, errFmtCannotGetSecretValue, ref)
 					}
 					for key, value := range data {

--- a/pkg/types/builder.go
+++ b/pkg/types/builder.go
@@ -142,8 +142,13 @@ func (g *Builder) buildSchema(f *Field, cfg *config.Resource, names []string, r 
 		return types.NewPointer(types.Universe.Lookup("string").Type()), nil
 	case schema.TypeMap, schema.TypeList, schema.TypeSet:
 		names = append(names, f.Name.Camel)
-		f.TerraformPaths = append(f.TerraformPaths, wildcard)
-		f.CRDPaths = append(f.CRDPaths, wildcard)
+		if f.Schema.Type != schema.TypeMap {
+			// We don't want to have a many-to-many relationship in case of a Map, since we use SecretReference as
+			// the type of XP field. In this case, we want to have a one-to-many relationship which is handled at
+			// runtime in the controller.
+			f.TerraformPaths = append(f.TerraformPaths, wildcard)
+			f.CRDPaths = append(f.CRDPaths, wildcard)
+		}
 		var elemType types.Type
 		switch et := f.Schema.Elem.(type) {
 		case schema.ValueType:

--- a/pkg/types/field.go
+++ b/pkg/types/field.go
@@ -169,7 +169,7 @@ func NewSensitiveField(g *Builder, cfg *config.Resource, r *resource, sch *schem
 	case "[]string", "[]*string":
 		f.FieldType = types.NewSlice(typeSecretKeySelector)
 	case "map[string]string", "map[string]*string":
-		f.FieldType = types.NewMap(types.Universe.Lookup("string").Type(), typeSecretKeySelector)
+		f.FieldType = typeSecretReference
 	}
 	f.TransformedName = name.NewFromCamel(f.FieldNameCamel).LowerCamelComputed
 	f.JSONTag = f.TransformedName

--- a/pkg/types/reference.go
+++ b/pkg/types/reference.go
@@ -37,6 +37,11 @@ var (
 		types.NewStruct(nil, nil),
 		nil,
 	)
+	typeSecretReference types.Type = types.NewNamed(
+		types.NewTypeName(token.NoPos, types.NewPackage(PackagePathXPCommonAPIs, "v1"), "SecretReference", nil),
+		types.NewStruct(nil, nil),
+		nil,
+	)
 	commentOptional = &comments.Comment{
 		Options: markers.Options{
 			KubebuilderOptions: markers.KubebuilderOptions{


### PR DESCRIPTION
### Description of your changes

This PR fixes the issues we are having with sensitive input fields of type map by using a `SecretReference` as the data type.

Fixes https://github.com/upbound/upjet/issues/134

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Tested with `aws_glue_connection` resource and [this PR](https://github.com/upbound/provider-aws/pull/142) using the below manifests:

```yaml
apiVersion: glue.aws.upbound.io/v1beta1
kind: Connection
metadata:
  annotations:
    meta.upbound.io/example-id: glue/v1beta1/connection
  labels:
    testing.upbound.io/example-name: example
  name: example
spec:
  forProvider:
    catalogId: "123456789012"
    connectionPropertiesSecretRef:
      name: example-secret
      namespace: upbound-system
    region: us-west-1
---
apiVersion: v1
kind: Secret
metadata:
  name: example-secret
  namespace: upbound-system
type: Opaque
stringData:
  JDBC_CONNECTION_URL: "jdbc:mysql://my-db/exampledatabase"
  PASSWORD: "examplepassword"
  USERNAME: "exampleusername"
```

[contribution process]: https://git.io/fj2m9
