### PR TITLE
Fix dockerfile link in generating-a-provider doc

### DIFF
--- a/docs/generating-a-provider.md
+++ b/docs/generating-a-provider.md
@@ -340,6 +340,6 @@ Now let's test our generated resources.
 [Terraform documentation for provider configuration]: https://registry.terraform.io/providers/integrations/github/latest/docs#argument-reference
 [github_repository]: https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository
 [github_branch]: https://registry.terraform.io/providers/integrations/github/latest/docs/resources/branch
-[this line in controller Dockerfile]: https://github.com/upbound/upjet-provider-template/blob/main/cluster/images/official-provider-template-controller/Dockerfile#L18-L26
+[this line in controller Dockerfile]: https://github.com/upbound/upjet-provider-template/blob/main/cluster/images/upjet-provider-template/Dockerfile#L13-L21
 [terraform-plugin-sdk]: https://github.com/hashicorp/terraform-plugin-sdk
 [new-resource-short]: add-new-resource-short.md

--- a/docs/generating-a-provider.md
+++ b/docs/generating-a-provider.md
@@ -340,6 +340,6 @@ Now let's test our generated resources.
 [Terraform documentation for provider configuration]: https://registry.terraform.io/providers/integrations/github/latest/docs#argument-reference
 [github_repository]: https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository
 [github_branch]: https://registry.terraform.io/providers/integrations/github/latest/docs/resources/branch
-[this line in controller Dockerfile]: https://github.com/upbound/upjet-provider-template/blob/main/cluster/images/upjet-provider-template/Dockerfile#L13-L21
+[this line in controller Dockerfile]: https://github.com/upbound/upjet-provider-template/blob/main/cluster/images/upjet-provider-template/Dockerfile#L20-L28
 [terraform-plugin-sdk]: https://github.com/hashicorp/terraform-plugin-sdk
 [new-resource-short]: add-new-resource-short.md


### PR DESCRIPTION
### Description of your changes

The link for Dockerfile code example in `docs/generating-a-provider.md` points to a non-existent file (Changed in [this commit](https://github.com/upbound/upjet-provider-template/commit/591c36d81fd5221a516cc04f5d7a4103fcc2a30b#diff-39dac810e98db30ef9660d54aef278297c4675bf19a1a21c97ed87a640d26837) ). Changed the link to point to the correct file and code section.


I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

