### PR TITLE
Use a local runtime.Scheme with the migration.Registry

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	k8s.io/client-go v0.25.0
 	k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed
 	sigs.k8s.io/controller-runtime v0.12.1
+	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2
 	sigs.k8s.io/yaml v1.3.0
 )
 
@@ -102,6 +103,5 @@ require (
 	k8s.io/component-base v0.25.0 // indirect
 	k8s.io/klog/v2 v2.70.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20220803162953-67bda5d908f1 // indirect
-	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 )

--- a/pkg/migration/converter.go
+++ b/pkg/migration/converter.go
@@ -16,11 +16,13 @@ package migration
 
 import (
 	"github.com/crossplane/crossplane-runtime/pkg/fieldpath"
+	xpv1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/json"
+	k8sjson "sigs.k8s.io/json"
 )
 
 const (
@@ -109,4 +111,15 @@ func FromGroupVersionKind(gvk schema.GroupVersionKind) GroupVersionKind {
 		Version: gvk.Version,
 		Kind:    gvk.Kind,
 	}
+}
+
+// workaround for:
+// https://github.com/kubernetes-sigs/structured-merge-diff/issues/230
+func convertToComposition(u map[string]interface{}) (*xpv1.Composition, error) {
+	buff, err := json.Marshal(u)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to marshal map to JSON")
+	}
+	c := &xpv1.Composition{}
+	return c, errors.Wrap(k8sjson.UnmarshalCaseSensitivePreserveInts(buff, c), "failed to unmarshal into a v1.Composition")
 }

--- a/pkg/migration/filesystem.go
+++ b/pkg/migration/filesystem.go
@@ -121,6 +121,9 @@ func (ft *FileSystemTarget) Put(o UnstructuredWithMetadata) error {
 	if err != nil {
 		return errors.Wrap(err, "cannot marshal object")
 	}
+	if err := os.MkdirAll(filepath.Dir(o.Metadata.Path), 0o750); err != nil {
+		return errors.Wrapf(err, "cannot mkdirall: %s", filepath.Dir(o.Metadata.Path))
+	}
 	if o.Metadata.Parents != "" {
 		f, err := ft.afero.OpenFile(o.Metadata.Path, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0600)
 		if err != nil {

--- a/pkg/migration/plan_generator.go
+++ b/pkg/migration/plan_generator.go
@@ -70,6 +70,10 @@ const (
 	stepStartComposites
 )
 
+const (
+	versionV010 = "0.1.0"
+)
+
 // PlanGenerator generates a migration.Plan reading the manifests available
 // from `source`, converting managed resources and compositions using the
 // available `migration.Converter`s registered in the `registry` and
@@ -134,7 +138,7 @@ func (pg *PlanGenerator) convert() error { //nolint: gocyclo
 				}
 			}
 		default:
-			if o.Metadata.IsComposite {
+			if o.Metadata.Category == CategoryComposite {
 				if err := pg.stepPauseComposite(&o); err != nil {
 					return errors.Wrap(err, errCompositePause)
 				}
@@ -142,7 +146,7 @@ func (pg *PlanGenerator) convert() error { //nolint: gocyclo
 				continue
 			}
 
-			if o.Metadata.IsClaim {
+			if o.Metadata.Category == CategoryClaim {
 				claims = append(claims, o)
 				continue
 			}
@@ -327,6 +331,7 @@ func (pg *PlanGenerator) buildPlan() {
 	pg.Plan.Spec.Steps[stepStartComposites].Name = "start-composites"
 	pg.Plan.Spec.Steps[stepStartComposites].Type = StepTypeApply
 	pg.Plan.Spec.Steps[stepStartComposites].Apply = &ApplyStep{}
+	pg.Plan.Version = versionV010
 }
 
 func (pg *PlanGenerator) addStepsForManagedResource(u *UnstructuredWithMetadata) error {

--- a/pkg/migration/plan_generator_test.go
+++ b/pkg/migration/plan_generator_test.go
@@ -56,17 +56,17 @@ func TestGeneratePlan(t *testing.T) {
 			fields: fields{
 				source: newTestSource(map[string]Metadata{
 					"testdata/plan/sourcevpc.yaml":   {},
-					"testdata/plan/claim.yaml":       {IsClaim: true},
+					"testdata/plan/claim.yaml":       {Category: CategoryClaim},
 					"testdata/plan/composition.yaml": {},
 					"testdata/plan/xrd.yaml":         {},
-					"testdata/plan/xr.yaml":          {IsComposite: true}}),
+					"testdata/plan/xr.yaml":          {Category: CategoryComposite}}),
 				target: newTestTarget(),
 				registry: getRegistryWithConverters(map[schema.GroupVersionKind]Converter{
 					fake.MigrationSourceGVK: &testConverter{},
 				}),
 			},
 			want: want{
-				migrationPlanPath: "testdata/plan/migration_plan.yaml",
+				migrationPlanPath: "testdata/plan/generated/migration_plan.yaml",
 				migratedResourceNames: []string{
 					"pause-managed/sample-vpc.vpcs.fakesourceapi.yaml",
 					"edit-claims/my-resource.myresources.test.com.yaml",

--- a/pkg/migration/registry.go
+++ b/pkg/migration/registry.go
@@ -18,18 +18,14 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
 	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/kubernetes/scheme"
 )
 
 const (
-	errFmtNewObject          = "failed to instantiate a new runtime.Object using scheme.Scheme for: %s"
+	errAddToScheme           = "failed to register types with the registry's scheme"
+	errFmtNewObject          = "failed to instantiate a new runtime.Object using runtime.Scheme for: %s"
 	errFmtNotManagedResource = "specified GVK does not belong to a managed resource: %s"
-)
-
-var (
-	// the default Converter registry
-	registry Registry = make(map[schema.GroupVersionKind]Converter)
 )
 
 // ResourceConversionFn is a function that converts the specified migration
@@ -42,23 +38,36 @@ type ResourceConversionFn func(mg resource.Managed) ([]resource.Managed, error)
 type ComposedTemplateConversionFn func(cmp v1.ComposedTemplate, convertedBase ...*v1.ComposedTemplate) error
 
 // Registry is a registry of `migration.Converter`s keyed with
-// the associated `schema.GroupVersionKind`s.
-type Registry map[schema.GroupVersionKind]Converter
+// the associated `schema.GroupVersionKind`s and an associated
+// runtime.Scheme with which the corresponding types are registered.
+type Registry struct {
+	converters map[schema.GroupVersionKind]Converter
+	scheme     *runtime.Scheme
+}
+
+// NewRegistry returns a new Registry initialized with
+// the specified runtime.Scheme
+func NewRegistry(scheme *runtime.Scheme) *Registry {
+	return &Registry{
+		converters: make(map[schema.GroupVersionKind]Converter),
+		scheme:     scheme,
+	}
+}
 
 // RegisterConverter registers the specified migration.Converter for the
 // specified GVK with the default Registry.
-func RegisterConverter(gvk schema.GroupVersionKind, conv Converter) {
+func (r *Registry) RegisterConverter(gvk schema.GroupVersionKind, conv Converter) {
 	// make sure a converter is being registered for a managed resource,
 	// and it's registered with our runtime scheme.
 	// This will be needed, during runtime, for properly converting resources
-	obj, err := scheme.Scheme.New(gvk)
+	obj, err := r.scheme.New(gvk)
 	if err != nil {
 		panic(errors.Wrapf(err, errFmtNewObject, gvk))
 	}
 	if _, ok := obj.(resource.Managed); !ok {
 		panic(errors.Errorf(errFmtNotManagedResource, gvk))
 	}
-	registry[gvk] = conv
+	r.converters[gvk] = conv
 }
 
 type delegatingConverter struct {
@@ -69,6 +78,9 @@ type delegatingConverter struct {
 // Resources converts from the specified migration source resource to
 // the migration target resources by calling the configured ResourceConversionFn.
 func (d delegatingConverter) Resources(mg resource.Managed) ([]resource.Managed, error) {
+	if d.rFn == nil {
+		return []resource.Managed{mg}, nil
+	}
 	return d.rFn(mg)
 }
 
@@ -76,6 +88,9 @@ func (d delegatingConverter) Resources(mg resource.Managed) ([]resource.Managed,
 // v1.ComposedTemplate to the migration target schema by calling the configured
 // ComposedTemplateConversionFn.
 func (d delegatingConverter) ComposedTemplates(cmp v1.ComposedTemplate, convertedBase ...*v1.ComposedTemplate) error {
+	if d.cmpFn == nil {
+		return nil
+	}
 	return d.cmpFn(cmp, convertedBase...)
 }
 
@@ -84,9 +99,25 @@ func (d delegatingConverter) ComposedTemplates(cmp v1.ComposedTemplate, converte
 // The specified GVK must belong to a Crossplane managed resource type and
 // the type must already have been registered with the client-go's
 // default scheme.
-func RegisterConversionFunctions(gvk schema.GroupVersionKind, rFn ResourceConversionFn, cmpFn ComposedTemplateConversionFn) {
-	RegisterConverter(gvk, delegatingConverter{
+func (r *Registry) RegisterConversionFunctions(gvk schema.GroupVersionKind, rFn ResourceConversionFn, cmpFn ComposedTemplateConversionFn) {
+	r.RegisterConverter(gvk, delegatingConverter{
 		rFn:   rFn,
 		cmpFn: cmpFn,
 	})
+}
+
+// AddToScheme registers types with this Registry's runtime.Scheme
+func (r *Registry) AddToScheme(sb func(scheme *runtime.Scheme) error) error {
+	return errors.Wrap(sb(r.scheme), errAddToScheme)
+}
+
+// GetRegisteredGVKs returns a list of registered GVKs
+// including v1.CompositionGroupVersionKind
+func (r *Registry) GetRegisteredGVKs() []schema.GroupVersionKind {
+	gvks := make([]schema.GroupVersionKind, 0, len(r.converters)+1)
+	for gvk := range r.converters {
+		gvks = append(gvks, gvk)
+	}
+	gvks = append(gvks, v1.CompositionGroupVersionKind)
+	return gvks
 }

--- a/pkg/migration/registry.go
+++ b/pkg/migration/registry.go
@@ -16,7 +16,7 @@ package migration
 
 import (
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
-	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
+	xpv1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -35,18 +35,20 @@ type ResourceConversionFn func(mg resource.Managed) ([]resource.Managed, error)
 // ComposedTemplateConversionFn is a function that converts from the specified
 // v1.ComposedTemplate's migration source resources to one or more migration
 // target resources.
-type ComposedTemplateConversionFn func(cmp v1.ComposedTemplate, convertedBase ...*v1.ComposedTemplate) error
+type ComposedTemplateConversionFn func(cmp xpv1.ComposedTemplate, convertedBase ...*xpv1.ComposedTemplate) error
 
 // Registry is a registry of `migration.Converter`s keyed with
 // the associated `schema.GroupVersionKind`s and an associated
 // runtime.Scheme with which the corresponding types are registered.
 type Registry struct {
-	converters map[schema.GroupVersionKind]Converter
-	scheme     *runtime.Scheme
+	converters     map[schema.GroupVersionKind]Converter
+	scheme         *runtime.Scheme
+	claimTypes     []schema.GroupVersionKind
+	compositeTypes []schema.GroupVersionKind
 }
 
 // NewRegistry returns a new Registry initialized with
-// the specified runtime.Scheme
+// the specified runtime.Scheme.
 func NewRegistry(scheme *runtime.Scheme) *Registry {
 	return &Registry{
 		converters: make(map[schema.GroupVersionKind]Converter),
@@ -87,7 +89,7 @@ func (d delegatingConverter) Resources(mg resource.Managed) ([]resource.Managed,
 // ComposedTemplates converts from the specified migration source
 // v1.ComposedTemplate to the migration target schema by calling the configured
 // ComposedTemplateConversionFn.
-func (d delegatingConverter) ComposedTemplates(cmp v1.ComposedTemplate, convertedBase ...*v1.ComposedTemplate) error {
+func (d delegatingConverter) ComposedTemplates(cmp xpv1.ComposedTemplate, convertedBase ...*xpv1.ComposedTemplate) error {
 	if d.cmpFn == nil {
 		return nil
 	}
@@ -111,13 +113,49 @@ func (r *Registry) AddToScheme(sb func(scheme *runtime.Scheme) error) error {
 	return errors.Wrap(sb(r.scheme), errAddToScheme)
 }
 
-// GetRegisteredGVKs returns a list of registered GVKs
-// including v1.CompositionGroupVersionKind
-func (r *Registry) GetRegisteredGVKs() []schema.GroupVersionKind {
-	gvks := make([]schema.GroupVersionKind, 0, len(r.converters)+1)
+// AddCompositionTypes registers the Composition types with
+// the registry's scheme. Only the v1 API of Compositions
+// is currently supported.
+func (r *Registry) AddCompositionTypes() error {
+	return r.AddToScheme(xpv1.AddToScheme)
+}
+
+// AddClaimType registers a new composite resource claim type
+// with the given GVK
+func (r *Registry) AddClaimType(gvk schema.GroupVersionKind) {
+	r.claimTypes = append(r.claimTypes, gvk)
+}
+
+// AddCompositeType registers a new composite resource type with the given GVK
+func (r *Registry) AddCompositeType(gvk schema.GroupVersionKind) {
+	r.compositeTypes = append(r.compositeTypes, gvk)
+}
+
+// GetManagedResourceGVKs returns a list of all registered managed resource
+// GVKs
+func (r *Registry) GetManagedResourceGVKs() []schema.GroupVersionKind {
+	gvks := make([]schema.GroupVersionKind, 0, len(r.converters))
 	for gvk := range r.converters {
 		gvks = append(gvks, gvk)
 	}
-	gvks = append(gvks, v1.CompositionGroupVersionKind)
+	return gvks
+}
+
+func (r *Registry) GetCompositionGVKs() []schema.GroupVersionKind {
+	// Composition types are registered with this registry's scheme
+	if _, ok := r.scheme.AllKnownTypes()[xpv1.CompositionGroupVersionKind]; ok {
+		return []schema.GroupVersionKind{xpv1.CompositionGroupVersionKind}
+	}
+	return nil
+}
+
+// GetAllRegisteredGVKs returns a list of registered GVKs
+// including v1.CompositionGroupVersionKind
+func (r *Registry) GetAllRegisteredGVKs() []schema.GroupVersionKind {
+	gvks := make([]schema.GroupVersionKind, 0, len(r.claimTypes)+len(r.compositeTypes)+len(r.converters)+1)
+	gvks = append(gvks, r.claimTypes...)
+	gvks = append(gvks, r.compositeTypes...)
+	gvks = append(gvks, r.GetManagedResourceGVKs()...)
+	gvks = append(gvks, xpv1.CompositionGroupVersionKind)
 	return gvks
 }

--- a/pkg/migration/testdata/plan/generated/migration_plan.yaml
+++ b/pkg/migration/testdata/plan/generated/migration_plan.yaml
@@ -55,3 +55,4 @@ spec:
       - start-composites/my-resource-dwjgh.xmyresources.test.com.yaml
     name: start-composites
     type: Apply
+version: 0.1.0

--- a/pkg/migration/types.go
+++ b/pkg/migration/types.go
@@ -28,6 +28,18 @@ const (
 	FinalizerPolicyRemove FinalizerPolicy = "Remove" // Default
 )
 
+// Resource categories
+const (
+	// CategoryClaim category for composite claim resources
+	CategoryClaim Category = "Claim"
+	// CategoryComposite category for composite resources
+	CategoryComposite Category = "Composite"
+	// CategoryComposition category for compositions
+	CategoryComposition Category = "Composition"
+	// CategoryManaged category for managed resources
+	CategoryManaged Category = "Managed"
+)
+
 // Plan represents a migration plan for migrating managed resources,
 // and associated composites and claims from a migration source provider
 // to a migration target provider.
@@ -114,6 +126,9 @@ type Resource struct {
 	Name string `json:"name"`
 }
 
+// Category specifies if a resource is a Claim, Composite or a Managed resource
+type Category string
+
 // Metadata holds metadata for an object read from a Source
 type Metadata struct {
 	// Path uniquely identifies the path for this object on its Source
@@ -121,10 +136,9 @@ type Metadata struct {
 	// colon separated list of parent `Path`s for fan-ins and fan-outs
 	// Example: resources/a.yaml:resources/b.yaml
 	Parents string
-	// IsComposite set if the object belongs to a Composite type
-	IsComposite bool
-	// IsClaim set if the object belongs to a Claim type
-	IsClaim bool
+	// Category specifies if the associated resource is a Claim, Composite or a
+	// Managed resource
+	Category Category
 }
 
 // UnstructuredWithMetadata represents an unstructured.Unstructured


### PR DESCRIPTION
<!--
Thank you for helping to improve Upjet!

Please read through https://git.io/fj2m9 if this is your first time opening a
Upjet pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Upjet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This PR proposes a change to use a local [runtime.Scheme](https://pkg.go.dev/k8s.io/apimachinery/pkg/runtime#Scheme) with the `migration.Registry` instead of a global scheme. The `migration.Registry` now has methods to register claim and composite resource types to be migrated.

It also mkdirs all folders before putting a file with the FileSystem target.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Tested with a migrator for proviider-terraform and provider-aws resources.

[contribution process]: https://git.io/fj2m9
