### PR TITLE
Rename migration.Converter.ComposedTemplates as Composition

### DIFF
--- a/pkg/migration/converter.go
+++ b/pkg/migration/converter.go
@@ -78,6 +78,9 @@ func sanitizeResource(m map[string]any) map[string]any {
 	return m
 }
 
+// removeNilValuedKeys removes nil values from the specified map so that
+// the serialized manifest do not contain corresponding superfluous YAML
+// nulls.
 func removeNilValuedKeys(m map[string]interface{}) {
 	for k, v := range m {
 		if v == nil {

--- a/pkg/migration/converter.go
+++ b/pkg/migration/converter.go
@@ -74,7 +74,27 @@ func sanitizeResource(m map[string]any) map[string]any {
 	if len(metadata) == 0 {
 		delete(m, "metadata")
 	}
+	removeNilValuedKeys(m)
 	return m
+}
+
+func removeNilValuedKeys(m map[string]interface{}) {
+	for k, v := range m {
+		if v == nil {
+			delete(m, k)
+			continue
+		}
+		switch c := v.(type) {
+		case map[string]any:
+			removeNilValuedKeys(c)
+		case []any:
+			for _, e := range c {
+				if cm, ok := e.(map[string]interface{}); ok {
+					removeNilValuedKeys(cm)
+				}
+			}
+		}
+	}
 }
 
 // ToSanitizedUnstructured converts the specified managed resource to an

--- a/pkg/migration/fake/objects.go
+++ b/pkg/migration/fake/objects.go
@@ -81,6 +81,10 @@ type Status struct {
 
 type Observation struct{}
 
+func (m *MigrationSourceObject) GetName() string {
+	return m.ObjectMeta.Name
+}
+
 type MigrationTargetObject struct {
 	mocks.MockManaged
 	// cannot inline v1.TypeMeta here as mocks.MockManaged is also inlined
@@ -93,7 +97,8 @@ type MigrationTargetObject struct {
 }
 
 type ObjectMeta struct {
-	Name string `json:"name,omitempty"`
+	Name         string `json:"name,omitempty"`
+	GenerateName string `json:"generateName,omitempty"`
 }
 
 type TargetSpec struct {
@@ -117,4 +122,12 @@ func (t *targetObjectKind) GroupVersionKind() schema.GroupVersionKind {
 
 func (m *MigrationTargetObject) GetObjectKind() schema.ObjectKind {
 	return &targetObjectKind{}
+}
+
+func (m *MigrationTargetObject) GetName() string {
+	return m.ObjectMeta.Name
+}
+
+func (m *MigrationTargetObject) GetGenerateName() string {
+	return m.ObjectMeta.GenerateName
 }

--- a/pkg/migration/fake/objects.go
+++ b/pkg/migration/fake/objects.go
@@ -106,3 +106,15 @@ type TargetSpecParameters struct {
 	CIDRBlock string            `json:"cidrBlock"`
 	Tags      map[string]string `json:"tags,omitempty"`
 }
+
+type targetObjectKind struct{}
+
+func (t *targetObjectKind) SetGroupVersionKind(_ schema.GroupVersionKind) {}
+
+func (t *targetObjectKind) GroupVersionKind() schema.GroupVersionKind {
+	return MigrationTargetGVK
+}
+
+func (m *MigrationTargetObject) GetObjectKind() schema.ObjectKind {
+	return &targetObjectKind{}
+}

--- a/pkg/migration/fake/objects.go
+++ b/pkg/migration/fake/objects.go
@@ -63,10 +63,15 @@ type SourceSpec struct {
 	ForProvider       SourceSpecParameters `json:"forProvider"`
 }
 
+type EmbeddedParameter struct {
+	Param *string `json:"param,omitempty"`
+}
+
 type SourceSpecParameters struct {
-	Region    *string `json:"region,omitempty"`
-	CIDRBlock string  `json:"cidrBlock"`
-	Tags      []Tag   `json:"tags,omitempty"`
+	Region    *string            `json:"region,omitempty"`
+	CIDRBlock string             `json:"cidrBlock"`
+	Tags      []Tag              `json:"tags,omitempty"`
+	TestParam *EmbeddedParameter `json:",inline"`
 }
 
 type Tag struct {
@@ -97,8 +102,9 @@ type MigrationTargetObject struct {
 }
 
 type ObjectMeta struct {
-	Name         string `json:"name,omitempty"`
-	GenerateName string `json:"generateName,omitempty"`
+	Name         string            `json:"name,omitempty"`
+	GenerateName string            `json:"generateName,omitempty"`
+	Labels       map[string]string `json:"labels,omitempty"`
 }
 
 type TargetSpec struct {
@@ -110,6 +116,7 @@ type TargetSpecParameters struct {
 	Region    *string           `json:"region,omitempty"`
 	CIDRBlock string            `json:"cidrBlock"`
 	Tags      map[string]string `json:"tags,omitempty"`
+	TestParam EmbeddedParameter `json:",inline"`
 }
 
 type targetObjectKind struct{}

--- a/pkg/migration/interfaces.go
+++ b/pkg/migration/interfaces.go
@@ -27,12 +27,16 @@ type Converter interface {
 	// resources to be created.
 	Resources(mg resource.Managed) ([]resource.Managed, error)
 
-	// ComposedTemplates takes a ComposedTemplate entry and returns zero or more
-	// ComposedTemplate with the new shape, including the necessary changes in
-	// its patches. Conversion of the v1.ComposedTemplate.Bases is handled
-	// via Converter.Resources and Converter.ComposedTemplates must only
-	// convert the other fields (`Patches`, `ConnectionDetails`, etc.)
-	ComposedTemplates(cmp v1.ComposedTemplate, convertedBase ...*v1.ComposedTemplate) error
+	// Composition receives a migration source v1.ComposedTemplate
+	// that has been converted, by a resource converter, to the
+	// v1.ComposedTemplates with new shapes specified in the
+	// `convertedTemplates` argument.
+	// Conversion of the v1.ComposedTemplate.Bases is handled
+	// via Converter.Resources and Converter.Composition must only
+	// convert the other fields (`Patches`, `ConnectionDetails`,
+	// `PatchSet`s, etc.)
+	// Returns the converted v1.PatchSet array or any errors encountered.
+	Composition(sourcePatchSets []v1.PatchSet, sourceTemplate v1.ComposedTemplate, convertedTemplates ...*v1.ComposedTemplate) ([]v1.PatchSet, error)
 }
 
 // Source is a source for reading resource manifests

--- a/pkg/migration/interfaces.go
+++ b/pkg/migration/interfaces.go
@@ -23,9 +23,9 @@ import (
 // from the migration source provider's schema to the migration target
 // provider's schema.
 type Converter interface {
-	// Resources takes a managed resource and returns zero or more managed
+	// Resource takes a managed resource and returns zero or more managed
 	// resources to be created.
-	Resources(mg resource.Managed) ([]resource.Managed, error)
+	Resource(mg resource.Managed) ([]resource.Managed, error)
 
 	// Composition receives a migration source v1.ComposedTemplate
 	// that has been converted, by a resource converter, to the

--- a/pkg/migration/patches.go
+++ b/pkg/migration/patches.go
@@ -1,0 +1,258 @@
+// Copyright 2023 Upbound Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migration
+
+import (
+	"fmt"
+	"reflect"
+	"regexp"
+	"strings"
+
+	xpv1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+var (
+	regexSlice = regexp.MustCompile(`(.+)\[\d+]`)
+	// this regex captures some malformed expressions
+	// (like mismatches in quotes, etc.)
+	regexMap     = regexp.MustCompile(`(.+)\[["|']?\D+["|']?]`)
+	regexJSONTag = regexp.MustCompile(`([^,]+)?(,.+)?`)
+)
+
+const (
+	jsonTagInlined = ",inline"
+)
+
+// removeInvalidPatches removes the (inherited) patches from
+// a (split) migration target composed template. The migration target composed
+// templates inherit patches from migration source templates by default, and
+// this function is responsible for removing patches (including references to
+// patch sets) that do not conform to the target composed template's schema.
+func removeInvalidPatches(c runtime.ObjectCreater, gvkSource, gvkTarget schema.GroupVersionKind, patchSets []xpv1.PatchSet, targetTemplate *xpv1.ComposedTemplate) error {
+	source, err := c.New(gvkSource)
+	if err != nil {
+		return errors.Wrapf(err, "failed to instantiate a new source object with GVK: %s", gvkSource.String())
+	}
+	target, err := c.New(gvkTarget)
+	if err != nil {
+		return errors.Wrapf(err, "failed to instantiate a new target object with GVK: %s", gvkTarget.String())
+	}
+
+	newPatches := make([]xpv1.Patch, 0, len(targetTemplate.Patches))
+	var patches []xpv1.Patch
+	for _, p := range targetTemplate.Patches {
+		switch p.Type { // nolint:exhaustive
+		case xpv1.PatchTypePatchSet:
+			ps := getNamedPatchSet(p.PatchSetName, patchSets)
+			if ps == nil {
+				// something is wrong with the patchset ref,
+				// we will just remove the ref
+				continue
+			}
+			// assert each of the patches in the set
+			// conform the target schema
+			patches = ps.Patches
+		default:
+			patches = []xpv1.Patch{p}
+		}
+		keep := true
+		for _, p := range patches {
+			ok, err := assertPatchSchemaConformance(p, source, target)
+			if err != nil {
+				return errors.Wrap(err, "failed to check whether the patch conforms to the target schema")
+			}
+			if !ok {
+				keep = false
+				break
+			}
+		}
+		if keep {
+			newPatches = append(newPatches, p)
+		}
+	}
+	targetTemplate.Patches = newPatches
+	return nil
+}
+
+// assertPatchSchemaConformance asserts that the specified patch actually
+// conforms the specified target schema. We also assert the patch conforms
+// to the migration source schema, which prevents an invalid patch from being
+// preserved after the conversion.
+func assertPatchSchemaConformance(p xpv1.Patch, source, target any) (bool, error) {
+	var targetPath *string
+	// because this is defaulting logic and what we default can be overridden
+	// later in the convert, the type switch is not exhaustive
+	// TODO: consider processing other patch types
+	switch p.Type { // nolint:exhaustive
+	case xpv1.PatchTypeFromCompositeFieldPath, "": // the default type
+		targetPath = p.ToFieldPath
+	case xpv1.PatchTypeToCompositeFieldPath:
+		targetPath = p.FromFieldPath
+	}
+	if targetPath == nil {
+		return false, nil
+	}
+	ok, err := assertNameAndTypeAtPath(reflect.TypeOf(source), reflect.TypeOf(target), splitPathComponents(*targetPath))
+	return ok, errors.Wrapf(err, "failed to assert patch schema for path: %s", *targetPath)
+}
+
+// splitPathComponents splits a fieldpath expression into its path components,
+// e.g., `m[a.b.c].a.b.c` is split into `m[a.b.c]`, `a`, `b`, `c`.
+func splitPathComponents(path string) []string {
+	components := strings.Split(path, ".")
+	result := make([]string, 0, len(components))
+	indexedExpression := false
+	for _, c := range components {
+		switch {
+		case indexedExpression:
+			result[len(result)-1] = fmt.Sprintf("%s.%s", result[len(result)-1], c)
+			if strings.Contains(c, "]") {
+				indexedExpression = false
+			}
+		default:
+			result = append(result, c)
+			if strings.Contains(c, "[") && !strings.Contains(c, "]") {
+				indexedExpression = true
+			}
+		}
+	}
+	return result
+}
+
+// assertNameAndTypeAtPath asserts that the migration source and target
+// templates both have the same kind for the type at the specified path.
+// Also validates the specific path is valid for the source.
+func assertNameAndTypeAtPath(source, target reflect.Type, pathComponents []string) (bool, error) { // nolint:gocyclo
+	if len(pathComponents) < 1 {
+		return compareKinds(source, target), nil
+	}
+
+	pathComponent := pathComponents[0]
+	if len(pathComponent) == 0 {
+		return false, errors.Errorf("failed to compare source and target structs. Invalid path: %s", strings.Join(pathComponents, "."))
+	}
+	m := regexMap.FindStringSubmatch(pathComponents[0])
+	if m == nil {
+		// if not a map index expression, check for slice indexing expression
+		m = regexSlice.FindStringSubmatch(pathComponents[0])
+	}
+	if m != nil {
+		// then a map component or a slicing component
+		pathComponent = m[1]
+	}
+
+	// assert the source and the target types
+	fSource, err := getFieldWithSerializedName(source, pathComponent)
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to assert source struct field kind at path: %s", strings.Join(pathComponents, "."))
+	}
+	if fSource == nil {
+		// then source field could not be found
+		return false, errors.Errorf("struct field %q does not exist for the source type %q at path: %s", pathComponent, source.String(), strings.Join(pathComponents, "."))
+	}
+	// now assert that this field actually exists for the target type
+	// with the same type
+	fTarget, err := getFieldWithSerializedName(target, pathComponent)
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to assert target struct field kind at path: %s", strings.Join(pathComponents, "."))
+	}
+	if fTarget == nil || !fTarget.IsExported() || !compareKinds(fSource.Type, fTarget.Type) {
+		return false, nil
+	}
+
+	nextSource, nextTarget := fSource.Type, fTarget.Type
+	if m != nil {
+		// parents are of map or slice type
+		nextSource = nextSource.Elem()
+		nextTarget = nextTarget.Elem()
+	}
+	return assertNameAndTypeAtPath(nextSource, nextTarget, pathComponents[1:])
+}
+
+// compareKinds compares the kinds of the specified types
+// dereferencing (following) pointer types.
+func compareKinds(s, t reflect.Type) bool {
+	if s.Kind() == reflect.Pointer {
+		s = s.Elem()
+	}
+	if t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+	return s.Kind() == t.Kind()
+}
+
+// getFieldWithSerializedName returns the field of a struct (if it exists)
+// with the specified serialized (JSON) name. Returns a nil (and a nil error)
+// if a field with the specified serialized name is not found
+// in the specified type.
+func getFieldWithSerializedName(t reflect.Type, name string) (*reflect.StructField, error) { // nolint:gocyclo
+	if t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+	if t.Kind() != reflect.Struct {
+		return nil, errors.Errorf("type is not a struct: %s", t.Name())
+	}
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		serializedName := f.Name
+		inlined := false
+		if fTag, ok := f.Tag.Lookup("json"); ok {
+			if m := regexJSONTag.FindStringSubmatch(fTag); m != nil && len(m[1]) > 0 {
+				serializedName = m[1]
+			}
+			if strings.HasSuffix(fTag, jsonTagInlined) {
+				inlined = true
+			}
+		}
+		if name == serializedName {
+			return &f, nil
+		}
+		if inlined {
+			inlinedType := f.Type
+			if inlinedType.Kind() == reflect.Pointer {
+				inlinedType = inlinedType.Elem()
+			}
+			if inlinedType.Kind() == reflect.Struct {
+				sf, err := getFieldWithSerializedName(inlinedType, name)
+				if err != nil {
+					return nil, errors.Wrapf(err, "failed to search for field %q in inlined type: %s", name, inlinedType.String())
+				}
+				if sf != nil {
+					return sf, nil
+				}
+			}
+		}
+	}
+	return nil, nil // not found
+}
+
+// getNamedPatchSet returns the patch set with the specified name
+// from the specified patch set slice. Returns nil if a patch set
+// with the given name is not found.
+func getNamedPatchSet(name *string, patchSets []xpv1.PatchSet) *xpv1.PatchSet {
+	if name == nil {
+		// if name is not specified, do not attempt to find a named patchset
+		return nil
+	}
+	for _, ps := range patchSets {
+		if *name == ps.Name {
+			return &ps
+		}
+	}
+	return nil
+}

--- a/pkg/migration/patches_test.go
+++ b/pkg/migration/patches_test.go
@@ -1,0 +1,89 @@
+// Copyright 2023 Upbound Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migration
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestSplitPathComponents(t *testing.T) {
+	tests := map[string]struct {
+		want []string
+	}{
+		`m['a.b.c']`: {
+			want: []string{`m['a.b.c']`},
+		},
+		`m["a.b.c"]`: {
+			want: []string{`m["a.b.c"]`},
+		},
+		`m[a.b.c]`: {
+			want: []string{`m[a.b.c]`},
+		},
+		`m[a.b.c.d.e]`: {
+			want: []string{`m[a.b.c.d.e]`},
+		},
+		`m['a.b.c.d.e']`: {
+			want: []string{`m['a.b.c.d.e']`},
+		},
+		`m['a.b']`: {
+			want: []string{`m['a.b']`},
+		},
+		`m['a']`: {
+			want: []string{`m['a']`},
+		},
+		`m['a'].b`: {
+			want: []string{`m['a']`, `b`},
+		},
+		`a`: {
+			want: []string{`a`},
+		},
+		`a.b`: {
+			want: []string{`a`, `b`},
+		},
+		`a.b.c`: {
+			want: []string{`a`, `b`, `c`},
+		},
+		`a.b.c.m['a.b.c']`: {
+			want: []string{`a`, `b`, `c`, `m['a.b.c']`},
+		},
+		`a.b.m['a.b.c'].c`: {
+			want: []string{`a`, `b`, `m['a.b.c']`, `c`},
+		},
+		`m['a.b.c'].a.b.c`: {
+			want: []string{`m['a.b.c']`, `a`, `b`, `c`},
+		},
+		`m[a.b.c].a.b.c`: {
+			want: []string{`m[a.b.c]`, `a`, `b`, `c`},
+		},
+		`m[0]`: {
+			want: []string{`m[0]`},
+		},
+		`a.b.c.m[0]`: {
+			want: []string{`a`, `b`, `c`, `m[0]`},
+		},
+		`m[0].a.b.c`: {
+			want: []string{`m[0]`, `a`, `b`, `c`},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			if diff := cmp.Diff(tt.want, splitPathComponents(name)); diff != "" {
+				t.Errorf("splitPathComponents(%s): -want, +got:\n%s\n", name, diff)
+			}
+		})
+	}
+}

--- a/pkg/migration/plan_generator.go
+++ b/pkg/migration/plan_generator.go
@@ -203,7 +203,7 @@ func (pg *PlanGenerator) convertResource(o UnstructuredWithMetadata) ([]Unstruct
 	if err != nil {
 		return nil, false, errors.Wrap(err, errResourceMigrate)
 	}
-	resources, err := conv.Resources(mg)
+	resources, err := conv.Resource(mg)
 	if err != nil {
 		return nil, false, errors.Wrap(err, errResourceMigrate)
 	}

--- a/pkg/migration/plan_generator_test.go
+++ b/pkg/migration/plan_generator_test.go
@@ -206,7 +206,7 @@ func (f *testTarget) Delete(o UnstructuredWithMetadata) error {
 
 type testConverter struct{}
 
-func (f *testConverter) Resources(mg xpresource.Managed) ([]xpresource.Managed, error) {
+func (f *testConverter) Resource(mg xpresource.Managed) ([]xpresource.Managed, error) {
 	s := mg.(*fake.MigrationSourceObject)
 	t := &fake.MigrationTargetObject{}
 	if _, err := CopyInto(s, t, fake.MigrationTargetGVK, "spec.forProvider.tags", "mockManaged"); err != nil {

--- a/pkg/migration/plan_generator_test.go
+++ b/pkg/migration/plan_generator_test.go
@@ -116,6 +116,7 @@ func TestGeneratePlan(t *testing.T) {
 					t.Errorf("GeneratePlan(): Expected generated migration resource file not found: %s", name)
 					continue
 				}
+				removeNilValuedKeys(u.Object)
 				if diff := cmp.Diff(u, gU.Object); diff != "" {
 					t.Errorf("GeneratePlan(): -wantMigratedResource, +gotMigratedResource with name %q: %s", name, diff)
 				}

--- a/pkg/migration/registry.go
+++ b/pkg/migration/registry.go
@@ -77,9 +77,9 @@ type delegatingConverter struct {
 	compFn CompositionConversionFn
 }
 
-// Resources converts from the specified migration source resource to
+// Resource converts from the specified migration source resource to
 // the migration target resources by calling the configured ResourceConversionFn.
-func (d delegatingConverter) Resources(mg resource.Managed) ([]resource.Managed, error) {
+func (d delegatingConverter) Resource(mg resource.Managed) ([]resource.Managed, error) {
 	if d.rFn == nil {
 		return []resource.Managed{mg}, nil
 	}

--- a/pkg/migration/testdata/plan/claim.yaml
+++ b/pkg/migration/testdata/plan/claim.yaml
@@ -8,3 +8,4 @@ spec:
     name: example
   parameters:
     tagValue: demo-test
+    region: us-west-1

--- a/pkg/migration/testdata/plan/composition.yaml
+++ b/pkg/migration/testdata/plan/composition.yaml
@@ -13,6 +13,22 @@ spec:
       patches:
         - fromFieldPath: "spec.parameters.tagValue"
           toFieldPath: spec.forProvider.tags[2].value
+    - name: ps2
+      patches:
+        - fromFieldPath: "spec.parameters.region"
+          toFieldPath: spec.forProvider.region
+    - name: ps3
+      patches:
+        - fromFieldPath: "spec.parameters.tagValue"
+          toFieldPath: metadata.labels[a.b.c.d/tag-value]
+    - name: ps4
+      patches:
+        - fromFieldPath: "spec.parameters.tagValue"
+          toFieldPath: metadata.labels['a.b.c.d.e/tag-value']
+    - name: ps5
+      patches:
+        - fromFieldPath: "spec.parameters.tagValue"
+          toFieldPath: metadata.labels["a.b.c.d.e.f/tag-value"]
   resources:
     - base:
         apiVersion: fakesourceapi/v1alpha1
@@ -36,3 +52,13 @@ spec:
           toFieldPath: spec.forProvider.tags[1].value
         - type: PatchSet
           patchSetName: ps1
+        - type: PatchSet
+          patchSetName: ps2
+        - type: PatchSet
+          patchSetName: ps3
+        - type: PatchSet
+          patchSetName: ps4
+        - type: PatchSet
+          patchSetName: ps5
+        - fromFieldPath: "spec.parameters.tagValue"
+          toFieldPath: spec.forProvider.param

--- a/pkg/migration/testdata/plan/composition.yaml
+++ b/pkg/migration/testdata/plan/composition.yaml
@@ -8,6 +8,11 @@ spec:
   compositeTypeRef:
     apiVersion: test.com/v1alpha1
     kind: XMyResource
+  patchSets:
+    - name: ps1
+      patches:
+        - fromFieldPath: "spec.parameters.tagValue"
+          toFieldPath: spec.forProvider.tags[2].value
   resources:
     - base:
         apiVersion: fakesourceapi/v1alpha1
@@ -29,5 +34,5 @@ spec:
           toFieldPath: spec.forProvider.tags[0].value
         - fromFieldPath: "spec.parameters.tagValue"
           toFieldPath: spec.forProvider.tags[1].value
-        - fromFieldPath: "spec.parameters.tagValue"
-          toFieldPath: spec.forProvider.tags[2].value
+        - type: PatchSet
+          patchSetName: ps1

--- a/pkg/migration/testdata/plan/generated/edit-claims/my-resource.myresources.test.com.yaml
+++ b/pkg/migration/testdata/plan/generated/edit-claims/my-resource.myresources.test.com.yaml
@@ -7,4 +7,5 @@ spec:
   compositionRef:
     name: example-migrated
   parameters:
+    region: us-west-1
     tagValue: demo-test

--- a/pkg/migration/testdata/plan/generated/edit-composites/my-resource-dwjgh.xmyresources.test.com.yaml
+++ b/pkg/migration/testdata/plan/generated/edit-composites/my-resource-dwjgh.xmyresources.test.com.yaml
@@ -24,6 +24,7 @@ spec:
     name: example-migrated
   compositionUpdatePolicy: Automatic
   parameters:
+    region: us-west-1
     tagValue: demo-test
   resourceRefs:
   - apiVersion: fakesourceapi/v1alpha1

--- a/pkg/migration/testdata/plan/generated/new-compositions/example-migrated.compositions.apiextensions.crossplane.io.yaml
+++ b/pkg/migration/testdata/plan/generated/new-compositions/example-migrated.compositions.apiextensions.crossplane.io.yaml
@@ -8,6 +8,11 @@ spec:
   compositeTypeRef:
     apiVersion: test.com/v1alpha1
     kind: XMyResource
+  patchSets:
+    - name: ps1
+      patches:
+        - fromFieldPath: "spec.parameters.tagValue"
+          toFieldPath: spec.forProvider.tags["key3"]
   resources:
   - base:
       apiVersion: faketargetapi/v1alpha1
@@ -29,5 +34,5 @@ spec:
       toFieldPath: spec.forProvider.tags["key1"]
     - fromFieldPath: spec.parameters.tagValue
       toFieldPath: spec.forProvider.tags["key2"]
-    - fromFieldPath: spec.parameters.tagValue
-      toFieldPath: spec.forProvider.tags["key3"]
+    - type: PatchSet
+      patchSetName: ps1

--- a/pkg/migration/testdata/plan/generated/new-compositions/example-migrated.compositions.apiextensions.crossplane.io.yaml
+++ b/pkg/migration/testdata/plan/generated/new-compositions/example-migrated.compositions.apiextensions.crossplane.io.yaml
@@ -13,6 +13,22 @@ spec:
       patches:
         - fromFieldPath: "spec.parameters.tagValue"
           toFieldPath: spec.forProvider.tags["key3"]
+    - name: ps2
+      patches:
+        - fromFieldPath: "spec.parameters.region"
+          toFieldPath: spec.forProvider.region
+    - name: ps3
+      patches:
+        - fromFieldPath: "spec.parameters.tagValue"
+          toFieldPath: metadata.labels[a.b.c.d/tag-value]
+    - name: ps4
+      patches:
+        - fromFieldPath: "spec.parameters.tagValue"
+          toFieldPath: metadata.labels['a.b.c.d.e/tag-value']
+    - name: ps5
+      patches:
+        - fromFieldPath: "spec.parameters.tagValue"
+          toFieldPath: metadata.labels["a.b.c.d.e.f/tag-value"]
   resources:
   - base:
       apiVersion: faketargetapi/v1alpha1
@@ -30,6 +46,16 @@ spec:
             key3: val3
     name: vpc
     patches:
+    - type: PatchSet
+      patchSetName: ps2
+    - type: PatchSet
+      patchSetName: ps3
+    - type: PatchSet
+      patchSetName: ps4
+    - type: PatchSet
+      patchSetName: ps5
+    - fromFieldPath: "spec.parameters.tagValue"
+      toFieldPath: spec.forProvider.param
     - fromFieldPath: spec.parameters.tagValue
       toFieldPath: spec.forProvider.tags["key1"]
     - fromFieldPath: spec.parameters.tagValue

--- a/pkg/migration/testdata/plan/generated/pause-composites/my-resource-dwjgh.xmyresources.test.com.yaml
+++ b/pkg/migration/testdata/plan/generated/pause-composites/my-resource-dwjgh.xmyresources.test.com.yaml
@@ -24,6 +24,7 @@ spec:
     name: example-migrated
   compositionUpdatePolicy: Automatic
   parameters:
+    region: us-west-1
     tagValue: demo-test
   resourceRefs:
   - apiVersion: fakesourceapi/v1alpha1

--- a/pkg/migration/testdata/plan/generated/start-composites/my-resource-dwjgh.xmyresources.test.com.yaml
+++ b/pkg/migration/testdata/plan/generated/start-composites/my-resource-dwjgh.xmyresources.test.com.yaml
@@ -24,6 +24,7 @@ spec:
     name: example-migrated
   compositionUpdatePolicy: Automatic
   parameters:
+    region: us-west-1
     tagValue: demo-test
   resourceRefs:
   - apiVersion: fakesourceapi/v1alpha1

--- a/pkg/migration/testdata/plan/xr.yaml
+++ b/pkg/migration/testdata/plan/xr.yaml
@@ -24,6 +24,7 @@ spec:
   compositionUpdatePolicy: Automatic
   parameters:
     tagValue: demo-test
+    region: us-west-1
   resourceRefs:
     - apiVersion: fakesourceapi/v1alpha1
       kind: VPC

--- a/pkg/migration/testdata/plan/xrd.yaml
+++ b/pkg/migration/testdata/plan/xrd.yaml
@@ -22,8 +22,11 @@ spec:
                 properties:
                   tagValue:
                     type: string
+                  region:
+                    type: string
                 required:
                 - tagValue
+                - region
                 type: object
             required:
             - parameters


### PR DESCRIPTION
<!--
Thank you for helping to improve Upjet!

Please read through https://git.io/fj2m9 if this is your first time opening a
Upjet pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Upjet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This PR proposes changes to the `migration.Converter` interface so that:
- `migration.Converter.ComposedTemplates` is renamed to `Composition`
- `migration.Converter.Composition` accepts the `spec.patchSets` of a Composition, and 
- Allows conversion of the `spec.patchSets` of Composition's by the registered migration converters.

Also we have the following improvements for the migration converters:
  - Include references to patch sets in the set of patches for migration targets by default (assumption is patch sets are reusable and thus probably applicable to the migration targets, so include refs to them by default). Target schemas are checked and if a referenced patchset does not conform to the target's schema, it's removed from the set of patches.
  - Remove patches from targets if the patch target/source field does not exist or is of a different type in the target, by default
  - Include patches in targets if the patch target/source field exists and is of the same type in the target, by default

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
