### PR TITLE
Add a test-case for config.GetExternalNameFromTemplated where the external-name template variable is not available

### DIFF
--- a/pkg/config/externalname_test.go
+++ b/pkg/config/externalname_test.go
@@ -79,6 +79,16 @@ func TestGetExternalNameFromTemplated(t *testing.T) {
 				name: "myname",
 			},
 		},
+		"NoExternalNameInTemplate": {
+			reason: "Should return the ID intact if there's no {{ .external_name }} variable in the template",
+			args: args{
+				tmpl: "olala:{{ .another }}:omama:{{ .someOther }}",
+				val:  "olala:val1:omama:val2",
+			},
+			want: want{
+				name: "olala:val1:omama:val2",
+			},
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
<!--
Thank you for helping to improve Upjet!

Please read through https://git.io/fj2m9 if this is your first time opening a
Upjet pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Upjet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This PR adds a new test-case for `config.GetExternalNameFromTemplated`, where the template expression passed as a parameter to the function, does not contain the `{{ .external_name }}` variable. The expected behavior in this case is that the ID string is returned intact, i.e., the ID is the external-name.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
`make reviewable`
[contribution process]: https://git.io/fj2m9
