### PR TITLE
Filter failed "terraform init" output for sensitive information

### DIFF
--- a/pkg/terraform/store.go
+++ b/pkg/terraform/store.go
@@ -1,6 +1,16 @@
-/*
-Copyright 2021 Upbound Inc.
-*/
+// Copyright 2021 Upbound Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package terraform
 
@@ -169,9 +179,9 @@ func (ws *WorkspaceStore) Workspace(ctx context.Context, c resource.SecretClient
 		cmd := w.executor.CommandContext(ctx, "terraform", "init", "-upgrade", "-input=false")
 		cmd.SetDir(w.dir)
 		out, err := cmd.CombinedOutput()
-		w.logger.Debug("init -upgrade ended", "out", string(out))
+		w.logger.Debug("init -upgrade ended", "out", ts.filterSensitiveInformation(string(out)))
 		if err != nil {
-			return w, errors.Wrapf(err, "cannot upgrade workspace: %s", string(out))
+			return w, errors.Wrapf(err, "cannot upgrade workspace: %s", ts.filterSensitiveInformation(string(out)))
 		}
 	}
 	attachmentConfig, err := ws.providerRunner.Start()
@@ -191,8 +201,8 @@ func (ws *WorkspaceStore) Workspace(ctx context.Context, c resource.SecretClient
 	cmd := w.executor.CommandContext(ctx, "terraform", "init", "-input=false")
 	cmd.SetDir(w.dir)
 	out, err := cmd.CombinedOutput()
-	w.logger.Debug("init ended", "out", string(out))
-	return w, errors.Wrapf(err, "cannot init workspace: %s", string(out))
+	w.logger.Debug("init ended", "out", ts.filterSensitiveInformation(string(out)))
+	return w, errors.Wrapf(err, "cannot init workspace: %s", ts.filterSensitiveInformation(string(out)))
 }
 
 // Remove deletes the workspace directory from the filesystem and erases its

--- a/pkg/terraform/workspace.go
+++ b/pkg/terraform/workspace.go
@@ -1,6 +1,16 @@
-/*
-Copyright 2021 Upbound Inc.
-*/
+// Copyright 2021 Upbound Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package terraform
 
@@ -111,6 +121,9 @@ func (w *Workspace) ApplyAsync(callback CallbackFn) error {
 		cmd.SetEnv(append(os.Environ(), w.env...))
 		cmd.SetDir(w.dir)
 		out, err := cmd.CombinedOutput()
+		if err != nil {
+			err = tferrors.NewApplyFailed(out)
+		}
 		w.LastOperation.MarkEnd()
 		w.logger.Debug("apply async ended", "out", w.filterFn(string(out)))
 		defer func() {
@@ -118,9 +131,6 @@ func (w *Workspace) ApplyAsync(callback CallbackFn) error {
 				w.logger.Info("callback failed", "error", cErr.Error())
 			}
 		}()
-		if err != nil {
-			err = tferrors.NewApplyFailed(out)
-		}
 	}()
 	return nil
 }
@@ -176,6 +186,9 @@ func (w *Workspace) DestroyAsync(callback CallbackFn) error {
 		cmd.SetEnv(append(os.Environ(), w.env...))
 		cmd.SetDir(w.dir)
 		out, err := cmd.CombinedOutput()
+		if err != nil {
+			err = tferrors.NewDestroyFailed(out)
+		}
 		w.LastOperation.MarkEnd()
 		w.logger.Debug("destroy async ended", "out", w.filterFn(string(out)))
 		defer func() {
@@ -183,9 +196,6 @@ func (w *Workspace) DestroyAsync(callback CallbackFn) error {
 				w.logger.Info("callback failed", "error", cErr.Error())
 			}
 		}()
-		if err != nil {
-			err = tferrors.NewDestroyFailed(out)
-		}
 	}()
 	return nil
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Upjet!

Please read through https://git.io/fj2m9 if this is your first time opening a
Upjet pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Upjet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #154 

This PR proposes a change for redacting sensitive information in `terraform init` output when debug-level logging or when updating the `status.conditions` of an MR.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Tested against https://github.com/coopnorge/provider-github/pull/6. Following `status.condition` is now reported with redacted sensitive information:
```yaml
status:
  atProvider: {}
  conditions:
  - lastTransitionTime: "2023-02-06T21:30:40Z"
    message: "connect failed: cannot get a terraform workspace for resource: cannot
      init workspace: \e[31m\e[0mThere are some problems with the configuration, described
      below.\n\nThe Terraform configuration must be valid before initialization so
      that\nTerraform can determine which modules and providers need to be installed.\e[0m\e[0m\n\e[31m\e[31m╷\e[0m\e[0m\n\e[31m│\e[0m
      \e[0m\e[1m\e[31mError: \e[0m\e[0m\e[1mInvalid resource name\e[0m\n\e[31m│\e[0m
      \e[0m\n\e[31m│\e[0m \e[0m\e[0m  on main.tf.json line 1, in resource.github_repository_file:\n\e[31m│\e[0m
      \e[0m   1: {\"provider\":{\"github\":{\"base_url\":\"REDACTED\",\"owner\":\"REDACTED\",\"REDACTED\":\"REDACTED\"}},\"resource\":{\"github_repository_file\":{\e[4m\"sample-file.txt\"\e[0m:{\"content\":\"HO.\",\"file\":\"test-file\",\"lifecycle\":{\"prevent_destroy\":true},\"name\":\"sample-file.txt\"}}},\"terraform\":{\"required_providers\":{\"github\":{\"source\":\"integrations/github\",\"version\":\"5.15.0\"}}}}\e[0m\n\e[31m│\e[0m
      \e[0m\n\e[31m│\e[0m \e[0mA name must start with a letter or underscore and may
      contain only letters,\n\e[31m│\e[0m \e[0mdigits, underscores, and dashes.\n\e[31m╵\e[0m\e[0m\n\e[0m\e[0m\n:
      exit status 1"
    reason: ReconcileError
    status: "False"
    type: Synced
```


[contribution process]: https://git.io/fj2m9
