### PR TITLE
Observe Only - POC

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/upbound/upjet
 
 go 1.19
 
+replace github.com/crossplane/crossplane-runtime => ../../crossplane/crossplane-runtime
+
 require (
 	github.com/antchfx/htmlquery v1.2.4
 	github.com/crossplane/crossplane v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -125,8 +125,6 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/crossplane/crossplane v1.10.0 h1:JP6TdhoZuRS27rYd+HCZNEBdf/1/w+rqIShW2qz/Qhk=
 github.com/crossplane/crossplane v1.10.0/go.mod h1:a90wo/wkTDHhh8artgsUiLtQu5DIYwA7biHPDoMssms=
-github.com/crossplane/crossplane-runtime v0.19.0-rc.0.0.20221012013934-bce61005a175 h1:qGLew6IazCwfgvY4/xh5lQiumip/WrULpQfW4duol6g=
-github.com/crossplane/crossplane-runtime v0.19.0-rc.0.0.20221012013934-bce61005a175/go.mod h1:o9ExoilV6k2M3qzSFoRVX4phuww0mLmjs1WrDTvsR4s=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/pkg/controller/external_test.go
+++ b/pkg/controller/external_test.go
@@ -47,6 +47,7 @@ type WorkspaceFns struct {
 	DestroyAsyncFn func(callback terraform.CallbackFn) error
 	DestroyFn      func(ctx context.Context) error
 	RefreshFn      func(ctx context.Context) (terraform.RefreshResult, error)
+	ImportFn       func(ctx context.Context, tr resource.Terraformed) (terraform.RefreshResult, error)
 	PlanFn         func(ctx context.Context) (terraform.PlanResult, error)
 }
 
@@ -68,6 +69,10 @@ func (c WorkspaceFns) Destroy(ctx context.Context) error {
 
 func (c WorkspaceFns) Refresh(ctx context.Context) (terraform.RefreshResult, error) {
 	return c.RefreshFn(ctx)
+}
+
+func (c WorkspaceFns) Import(ctx context.Context, tr resource.Terraformed) (terraform.RefreshResult, error) {
+	return c.ImportFn(ctx, tr)
 }
 
 func (c WorkspaceFns) Plan(ctx context.Context) (terraform.PlanResult, error) {

--- a/pkg/controller/interfaces.go
+++ b/pkg/controller/interfaces.go
@@ -23,6 +23,7 @@ type Workspace interface {
 	DestroyAsync(terraform.CallbackFn) error
 	Destroy(context.Context) error
 	Refresh(context.Context) (terraform.RefreshResult, error)
+	Import(context.Context, resource.Terraformed) (terraform.RefreshResult, error)
 	Plan(context.Context) (terraform.PlanResult, error)
 }
 

--- a/pkg/pipeline/templates/crd_types.go.tmpl
+++ b/pkg/pipeline/templates/crd_types.go.tmpl
@@ -13,6 +13,11 @@ import (
 
 {{ .Types }}
 
+type {{ .CRD.Kind }}FullState struct {
+    {{ .CRD.ForProviderType }} `json:",inline"`
+    {{ .CRD.AtProviderType }} `json:",inline"`
+}
+
 // {{ .CRD.Kind }}Spec defines the desired state of {{ .CRD.Kind }}
 type {{ .CRD.Kind }}Spec struct {
 	{{ .XPCommonAPIsPackageAlias }}ResourceSpec `json:",inline"`
@@ -22,7 +27,7 @@ type {{ .CRD.Kind }}Spec struct {
 // {{ .CRD.Kind }}Status defines the observed state of {{ .CRD.Kind }}.
 type {{ .CRD.Kind }}Status struct {
 	{{ .XPCommonAPIsPackageAlias }}ResourceStatus `json:",inline"`
-	AtProvider          {{ .CRD.AtProviderType }} `json:"atProvider,omitempty"`
+	AtProvider         {{ .CRD.Kind }}FullState `json:"atProvider,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/pkg/pipeline/templates/crd_types.go.tmpl
+++ b/pkg/pipeline/templates/crd_types.go.tmpl
@@ -13,11 +13,6 @@ import (
 
 {{ .Types }}
 
-type {{ .CRD.Kind }}FullState struct {
-    {{ .CRD.ForProviderType }} `json:",inline"`
-    {{ .CRD.AtProviderType }} `json:",inline"`
-}
-
 // {{ .CRD.Kind }}Spec defines the desired state of {{ .CRD.Kind }}
 type {{ .CRD.Kind }}Spec struct {
 	{{ .XPCommonAPIsPackageAlias }}ResourceSpec `json:",inline"`
@@ -27,7 +22,7 @@ type {{ .CRD.Kind }}Spec struct {
 // {{ .CRD.Kind }}Status defines the observed state of {{ .CRD.Kind }}.
 type {{ .CRD.Kind }}Status struct {
 	{{ .XPCommonAPIsPackageAlias }}ResourceStatus `json:",inline"`
-	AtProvider         {{ .CRD.Kind }}FullState `json:"atProvider,omitempty"`
+	AtProvider         {{ .CRD.AtProviderType }} `json:"atProvider,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/pkg/terraform/store.go
+++ b/pkg/terraform/store.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
+	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	xpresource "github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/pkg/errors"
 	"github.com/spf13/afero"
@@ -155,8 +156,13 @@ func (ws *WorkspaceStore) Workspace(ctx context.Context, c resource.SecretClient
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot create a new file producer")
 	}
-	if err := fp.EnsureTFState(ctx); err != nil {
+
+	if err = fp.EnsureTFState(ctx); err != nil {
 		return nil, errors.Wrap(err, "cannot ensure tfstate file")
+	}
+	w.trID, err = fp.Config.ExternalName.GetIDFn(ctx, meta.GetExternalName(fp.Resource), fp.parameters, fp.Setup.Map())
+	if err != nil {
+		return nil, errors.Wrap(err, errGetID)
 	}
 	isNeedProviderUpgrade, err := fp.needProviderUpgrade()
 	if err != nil {

--- a/pkg/types/builder.go
+++ b/pkg/types/builder.go
@@ -277,6 +277,14 @@ func (r *resource) addParameterField(f *Field, field *types.Var) {
 }
 
 func (r *resource) addObservationField(f *Field, field *types.Var) {
+	for _, obsF := range r.obsFields {
+		if obsF.Name() == field.Name() {
+			// If the field is already added, we don't add it again.
+			return
+		}
+	}
+	f.Comment.Reference = config.Reference{}
+
 	r.obsFields = append(r.obsFields, field)
 	r.obsTags = append(r.obsTags, fmt.Sprintf(`json:"%s" tf:"%s"`, f.JSONTag, f.TFTag))
 }

--- a/pkg/types/field.go
+++ b/pkg/types/field.go
@@ -204,10 +204,18 @@ func (f *Field) AddToResource(g *Builder, r *resource, typeNames *TypeNames) {
 	}
 
 	field := types.NewField(token.NoPos, g.Package, f.FieldNameCamel, f.FieldType, false)
-	switch {
-	case IsObservation(f.Schema):
-		r.addObservationField(f, field)
-	default:
+	/*	switch {
+		case IsObservation(f.Schema):
+			r.addObservationField(f, field)
+		default:
+			if f.AsBlocksMode {
+				f.TFTag = strings.TrimSuffix(f.TFTag, ",omitempty")
+			}
+			r.addParameterField(f, field)
+		}*/
+
+	r.addObservationField(f, field)
+	if !IsObservation(f.Schema) {
 		if f.AsBlocksMode {
 			f.TFTag = strings.TrimSuffix(f.TFTag, ",omitempty")
 		}

--- a/pkg/types/markers/kubebuilder.go
+++ b/pkg/types/markers/kubebuilder.go
@@ -15,7 +15,7 @@ func (o KubebuilderOptions) String() string {
 
 	if o.Required != nil {
 		if *o.Required {
-			m += "+kubebuilder:validation:Required\n"
+			m += "+kubebuilder:validation:Optional\n"
 		} else {
 			m += "+kubebuilder:validation:Optional\n"
 		}


### PR DESCRIPTION
### Description of your changes

This is just a POC PR for the required changes in upjet for the [Observe Only proposal](https://github.com/crossplane/crossplane/pull/3531).

Changes in this PR will probably be split into multiple PRs:
- Include all state under status.atProvider, i.e. status.atProvider is a superset of spec.atProvider. See [the discussion](https://github.com/crossplane/crossplane/pull/3531#discussion_r1049061547) leading to this in addition to what is already proposed in the design.
- Define CEL rules to mark fields as required depending on the management policy.
- Usage of `Terraform import` when management policy is Observe Only.

I have:

- [ ] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Together with provider-gcp, by generating new schemas and observing resources.
