### PR TITLE
chore: enphasize functions usage image on new resource doc

### DIFF
--- a/docs/add-new-resource-long.md
+++ b/docs/add-new-resource-long.md
@@ -257,7 +257,10 @@ You can always check resource configurations of existing jet Providers as
 further examples under `config/<group>/config.go` in their repositories.
 
 _Please see [this figure] to understand why we really need 3 different
-functions to configure external names and, it visualizes which is used how._
+functions to configure external names and, it visualizes which is used how:_
+![Alt text](./images/upjet-externalname.png)
+_Note that, initially, GetIDFn will use the external-name annotation to set the terraform.tfstate id and, after that, it uses the terraform.tfstate id to update the external-name annotation. For cases where both values are different, both GetIDFn and GetExternalNameFn must be set in order to have the correct configuration._
+
 
 ### Cross Resource Referencing
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Upjet!

Please read through https://git.io/fj2m9 if this is your first time opening a
Upjet pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
This PR has the intention to highlight and let more visible the upjet-externalname image.
I followed the documentation a few weeks ago to create a new upjet provider based on the hashicorp vault terraform provider. I took a long time to understand how the functions for setting the external name work, and I could only make the right configuration for some Vault resources after finding the image, that I thought it was a bit hidden among all the other information. That image made the understandement of the full process that upjet follows for setting the external-name and the terraform fields, and I believe it'll be very helpful for future users to configure their providers if it's more exposed.
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Upjet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary. (not needed)

### How has this code been tested
By checking the readme file after the change
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
