### PR TITLE
Generate CEL validation rules not to enforce required fields when ObserveOnly

### DIFF
--- a/pkg/config/externalname.go
+++ b/pkg/config/externalname.go
@@ -63,6 +63,7 @@ func ParameterAsIdentifier(param string) ExternalName {
 		param,
 		param + "_prefix",
 	}
+	e.IdentifierFields = []string{param}
 	return e
 }
 

--- a/pkg/config/resource.go
+++ b/pkg/config/resource.go
@@ -104,6 +104,12 @@ type ExternalName struct {
 	// assigned by the provider, like AWS VPC where it gets vpc-21kn123 identifier
 	// and not let you name it.
 	DisableNameInitializer bool
+
+	// IdentifierFields are the fields that are used to construct external
+	// resource identifier. We need to know these fields no matter what the
+	// management policy is including the Observe Only, different from other
+	// (required) fields.
+	IdentifierFields []string
 }
 
 // References represents reference resolver configurations for the fields of a

--- a/pkg/pipeline/crd.go
+++ b/pkg/pipeline/crd.go
@@ -90,6 +90,7 @@ func (cg *CRDGenerator) Generate(cfg *config.Resource) (string, error) {
 			"Kind":            cfg.Kind,
 			"ForProviderType": gen.ForProviderType.Obj().Name(),
 			"AtProviderType":  gen.AtProviderType.Obj().Name(),
+			"ValidationRules": gen.ValidationRules,
 			"Path":            cfg.Path,
 		},
 		"Provider": map[string]string{

--- a/pkg/pipeline/templates/crd_types.go.tmpl
+++ b/pkg/pipeline/templates/crd_types.go.tmpl
@@ -37,6 +37,7 @@ type {{ .CRD.Kind }}Status struct {
 type {{ .CRD.Kind }} struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
+	{{- .CRD.ValidationRules }}
 	Spec              {{ .CRD.Kind }}Spec   `json:"spec"`
 	Status            {{ .CRD.Kind }}Status `json:"status,omitempty"`
 }

--- a/pkg/types/builder.go
+++ b/pkg/types/builder.go
@@ -275,10 +275,10 @@ type resource struct {
 func (r *resource) addParameterField(f *Field, field *types.Var) {
 	req := !f.Schema.Optional
 	// Note(turkenh): We are collecting the top level required parameters that
-	// are not identifier fields. This is to generate CEL validation rules for
-	// those parameters not to require them if management policy is set Observe
-	// Only. In other words, if we are not creating or managing the resource, we
-	// don't need to provide those parameters which are:
+	// are not identifier fields. This is for generating CEL validation rules for
+	// those parameters and not to require them if the management policy is set
+	// Observe Only. In other words, if we are not creating or managing the
+	// resource, we don't need to provide those parameters which are:
 	// - req => required
 	// - !f.Identifier => not identifiers - i.e. region, zone, etc.
 	// - len(f.CanonicalPaths) == 1 => top level, i.e. not a nested field

--- a/pkg/types/builder_test.go
+++ b/pkg/types/builder_test.go
@@ -249,7 +249,7 @@ func TestBuild(t *testing.T) {
 				},
 			},
 			want: want{
-				forProvider: `type example.Parameters struct{Enable *bool "json:\"enable,omitempty\" tf:\"enable,omitempty\""; ID *int64 "json:\"id\" tf:\"id,omitempty\""; Name *string "json:\"name\" tf:\"name,omitempty\""}`,
+				forProvider: `type example.Parameters struct{Enable *bool "json:\"enable,omitempty\" tf:\"enable,omitempty\""; ID *int64 "json:\"id,omitempty\" tf:\"id,omitempty\""; Name *string "json:\"name,omitempty\" tf:\"name,omitempty\""}`,
 				atProvider:  `type example.Observation struct{Config *string "json:\"config,omitempty\" tf:\"config,omitempty\""; Enable *bool "json:\"enable,omitempty\" tf:\"enable,omitempty\""; ID *int64 "json:\"id,omitempty\" tf:\"id,omitempty\""; Name *string "json:\"name,omitempty\" tf:\"name,omitempty\""; Value *float64 "json:\"value,omitempty\" tf:\"value,omitempty\""}`,
 			},
 		},
@@ -282,7 +282,7 @@ func TestBuild(t *testing.T) {
 				},
 			},
 			want: want{
-				forProvider: `type example.Parameters struct{List []*string "json:\"list\" tf:\"list,omitempty\""; ResourceIn map[string]example.ResourceInParameters "json:\"resourceIn\" tf:\"resource_in,omitempty\""}`,
+				forProvider: `type example.Parameters struct{List []*string "json:\"list,omitempty\" tf:\"list,omitempty\""; ResourceIn map[string]example.ResourceInParameters "json:\"resourceIn,omitempty\" tf:\"resource_in,omitempty\""}`,
 				atProvider:  `type example.Observation struct{List []*string "json:\"list,omitempty\" tf:\"list,omitempty\""; ResourceIn map[string]example.ResourceInParameters "json:\"resourceIn,omitempty\" tf:\"resource_in,omitempty\""; ResourceOut map[string]example.ResourceOutObservation "json:\"resourceOut,omitempty\" tf:\"resource_out,omitempty\""}`,
 			},
 		},
@@ -354,7 +354,7 @@ func TestBuild(t *testing.T) {
 				},
 			},
 			want: want{
-				forProvider: `type example.Parameters struct{Name *string "json:\"name\" tf:\"name,omitempty\""; ReferenceID *string "json:\"referenceId,omitempty\" tf:\"reference_id,omitempty\""; ExternalResourceID *github.com/crossplane/crossplane-runtime/apis/common/v1.Reference "json:\"externalResourceId,omitempty\" tf:\"-\""; ReferenceIDSelector *github.com/crossplane/crossplane-runtime/apis/common/v1.Selector "json:\"referenceIdSelector,omitempty\" tf:\"-\""}`,
+				forProvider: `type example.Parameters struct{Name *string "json:\"name,omitempty\" tf:\"name,omitempty\""; ReferenceID *string "json:\"referenceId,omitempty\" tf:\"reference_id,omitempty\""; ExternalResourceID *github.com/crossplane/crossplane-runtime/apis/common/v1.Reference "json:\"externalResourceId,omitempty\" tf:\"-\""; ReferenceIDSelector *github.com/crossplane/crossplane-runtime/apis/common/v1.Selector "json:\"referenceIdSelector,omitempty\" tf:\"-\""}`,
 				atProvider:  `type example.Observation struct{Name *string "json:\"name,omitempty\" tf:\"name,omitempty\""; ReferenceID *string "json:\"referenceId,omitempty\" tf:\"reference_id,omitempty\""}`,
 			},
 		},

--- a/pkg/types/field.go
+++ b/pkg/types/field.go
@@ -32,6 +32,7 @@ type Field struct {
 	Reference                                *config.Reference
 	TransformedName                          string
 	SelectorName                             string
+	Identifier                               bool
 }
 
 // getDocString tries to extract the documentation string for the specified
@@ -92,6 +93,13 @@ func NewField(g *Builder, cfg *config.Resource, r *resource, sch *schema.Schema,
 		Name:           name.NewFromSnake(snakeFieldName),
 		FieldNameCamel: name.NewFromSnake(snakeFieldName).Camel,
 		AsBlocksMode:   asBlocksMode,
+	}
+
+	for _, ident := range cfg.ExternalName.IdentifierFields {
+		if ident == snakeFieldName {
+			f.Identifier = true
+			break
+		}
 	}
 
 	var commentText string

--- a/pkg/types/field.go
+++ b/pkg/types/field.go
@@ -96,6 +96,9 @@ func NewField(g *Builder, cfg *config.Resource, r *resource, sch *schema.Schema,
 	}
 
 	for _, ident := range cfg.ExternalName.IdentifierFields {
+		// TODO(turkenh): Could there be a nested identifier field? No, known
+		// cases so far but we would need to handle that if/once there is one,
+		// which is missing here.
 		if ident == snakeFieldName {
 			f.Identifier = true
 			break


### PR DESCRIPTION
### Description of your changes

This PR generates [CEL validation rules](https://kubernetes.io/blog/2022/09/23/crd-validation-rules-beta/) not to enforce all the required fields when Observe Only as proposed [in the design](https://github.com/crossplane/crossplane/pulls/turkenh).

This is achieved by adding the following CEL rule for non-identifier (e.g. `region`) top level parameters (i.e. `spec.forProvider.<param>`) after removing the `// +kubebuilder:validation:Required` marker:

```
// +kubebuilder:validation:XValidation:rule="self.managementPolicy == 'ObserveOnly' || has(self.forProvider.<parameter>)",message="<parameter> is a required parameter"
```

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Tested by re-generating schema for upbound/provider-aws, check [this PR](https://github.com/upbound/provider-aws/pull/578) to see it in action.

[contribution process]: https://git.io/fj2m9
