### PR TITLE
Add `OWNERS.md` and `CODEOWNERS`

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,18 @@
+# This file controls automatic PR reviewer assignment. See the following docs:
+#
+# * https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+# * https://docs.github.com/en/organizations/organizing-members-into-teams/managing-code-review-settings-for-your-team
+#
+# The goal of this file is for most PRs to automatically and fairly have one
+# maintainer set as PR reviewers. All maintainers have permission to approve 
+# and merge PRs. All PRs must be approved by at least one maintainer before being merged.
+# 
+# Where possible, prefer explicitly specifying a maintainer who is a subject
+# matter expert for a particular part of the codebase rather than using the
+# @upbound/team-extensions group.
+#
+# See also OWNERS.md for governance details
+
+# Fallback owners
+*			@ulucinar
+*			@sergenyalcin

--- a/OWNERS.md
+++ b/OWNERS.md
@@ -1,0 +1,13 @@
+# OWNERS
+
+This page lists all maintainers for **this** repository. Each repository in the [Upbound
+organization](https://github.com/upbound/) will list their repository maintainers in their own
+`OWNERS.md` file.
+
+
+## Maintainers
+
+* Alper Ulucinar <alper@upbound.com> ([ulucinar](https://github.com/ulucinar))
+* Sergen Yalcin <sergen@upbound.com> ([sergenyalcin](https://github.com/sergenyalcin))
+
+See [CODEOWNERS](./CODEOWNERS) for automatic PR assignment.


### PR DESCRIPTION
### Description of your changes

In this PR, the "OWNERS.md" file and the "CODEOWNERS" file have been added.

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Read and followed Crossplane's [contribution process](https://git.io/fj2m9).