### PR TITLE
Add upjet runtime Prometheus metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,8 +14,10 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.0
 	github.com/iancoleman/strcase v0.2.0
 	github.com/json-iterator/go v1.1.12
+	github.com/mitchellh/go-ps v1.0.0
 	github.com/muvaf/typewriter v0.0.0-20210910160850-80e49fe1eb32
 	github.com/pkg/errors v0.9.1
+	github.com/prometheus/client_golang v1.12.2
 	github.com/spf13/afero v1.9.2
 	github.com/tmccombs/hcl2json v0.3.3
 	github.com/yuin/goldmark v1.4.13
@@ -79,7 +81,6 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/prometheus/client_golang v1.12.2 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.32.1 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -411,6 +411,8 @@ github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa1
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
+github.com/mitchellh/go-ps v1.0.0 h1:i6ampVEEF4wQFF+bkYfwYgY+F/uYJDktmvLPf7qIgjc=
+github.com/mitchellh/go-ps v1.0.0/go.mod h1:J4lOc8z8yJs6vUwklHw2XEIiT4z4C40KtWVN3nvg8Pg=
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/mitchellh/go-testing-interface v1.14.1 h1:jrgshOhYAUVNMAJiKbEu7EqAwgJJ2JqpQmpLJOu07cU=
 github.com/mitchellh/go-testing-interface v1.14.1/go.mod h1:gfgS7OtZj6MA4U1UrDRp04twqAjfvlZyCfX3sDjEym8=

--- a/pkg/controller/external_test.go
+++ b/pkg/controller/external_test.go
@@ -225,7 +225,7 @@ func TestObserve(t *testing.T) {
 				w: WorkspaceFns{
 					RefreshFn: func(_ context.Context) (terraform.RefreshResult, error) {
 						return terraform.RefreshResult{
-							IsApplying: true,
+							ASyncInProgress: true,
 						}, nil
 					},
 				},

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,0 +1,90 @@
+// Copyright 2023 Upbound Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+const (
+	promNSUpjet     = "upjet"
+	promSysTF       = "terraform"
+	promSysResource = "resource"
+)
+
+// ExecMode is the Terraform CLI execution mode label
+type ExecMode int
+
+const (
+	// ModeSync represents the synchronous execution mode
+	ModeSync ExecMode = iota
+	// ModeASync represents the asynchronous execution mode
+	ModeASync
+)
+
+// String converts an execMode to string
+func (em ExecMode) String() string {
+	switch em {
+	case ModeSync:
+		return "sync"
+	case ModeASync:
+		return "async"
+	default:
+		return "unknown"
+	}
+}
+
+var (
+	// CLITime is the Terraform CLI execution times histogram.
+	CLITime = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: promNSUpjet,
+		Subsystem: promSysTF,
+		Name:      "cli_duration",
+		Help:      "Measures in seconds how long it takes a Terraform CLI invocation to complete",
+		Buckets:   []float64{1.0, 3, 5, 10, 15, 30, 60, 120, 300},
+	}, []string{"subcommand", "mode"})
+
+	// CLIExecutions are the active number of terraform CLI invocations.
+	CLIExecutions = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: promNSUpjet,
+		Subsystem: promSysTF,
+		Name:      "active_cli_invocations",
+		Help:      "The number of active (running) Terraform CLI invocations",
+	}, []string{"subcommand", "mode"})
+
+	// TFProcesses are the active number of
+	// terraform CLI & Terraform provider processes running.
+	TFProcesses = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: promNSUpjet,
+		Subsystem: promSysTF,
+		Name:      "running_processes",
+		Help:      "The number of running Terraform CLI and Terraform provider processes",
+	}, []string{"type"})
+
+	// TTRMeasurements are the time-to-readiness measurements for
+	// the managed resources.
+	TTRMeasurements = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: promNSUpjet,
+		Subsystem: promSysResource,
+		Name:      "ttr",
+		Help:      "Measures in seconds the time-to-readiness (TTR) for managed resources",
+		Buckets:   []float64{10, 15, 30, 60, 120, 300, 600, 1800, 3600},
+	}, []string{"group", "version", "kind"})
+)
+
+func init() {
+	metrics.Registry.MustRegister(CLITime, CLIExecutions, TFProcesses, TTRMeasurements)
+}

--- a/pkg/terraform/operation_test.go
+++ b/pkg/terraform/operation_test.go
@@ -60,7 +60,7 @@ func TestOperation(t *testing.T) {
 			},
 			want: want{
 				checks: func(o *Operation) bool {
-					return o.Type == "" && o.StartTime() == nil && o.EndTime() == nil
+					return o.Type == "" && o.startTime == nil && o.endTime == nil
 				},
 				result: true,
 			},

--- a/pkg/terraform/workspace_test.go
+++ b/pkg/terraform/workspace_test.go
@@ -219,7 +219,7 @@ func TestWorkspaceRefresh(t *testing.T) {
 			},
 			want: want{
 				r: RefreshResult{
-					IsApplying: true,
+					ASyncInProgress: true,
 				},
 			},
 		},


### PR DESCRIPTION
<!--
Thank you for helping to improve Upjet!

Please read through https://git.io/fj2m9 if this is your first time opening a
Upjet pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Upjet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #167 

This PR adds the following Prometheus metrics to the upjet runtime. These are upjet runtime metrics, meaning that they are exposed by a provider while reconciling its managed resources via upjet:
- `upjet_terraform_cli_duration`: This is a histogram metric and reports statistics, in seconds, on how long it takes a Terraform CLI invocation to complete.
- `upjet_terraform_active_cli_invocations`: This is a gauge metric and it's the number of active (running) Terraform CLI invocations.
- `upjet_terraform_running_processes`: This is a gauge metric and it's the number of running Terraform CLI and Terraform provider processes.
- `upjet_resource_ttr`: This is a histogram metric and it measures, in seconds, the time-to-readiness for managed resources.

`terraform.Operation.MarkStart` now atomically checks for any previous ongoing operation before starting a new one, and
`terraform.Operation.{Start,End}Time` no longer return pointers that could potentially be used to modify the shared state outside of critical sections.

The following labels are available for the exposed runtime metrics:
- `upjet_terraform_cli_duration`: `subcommand` and `mode`.
  - `subcommand`: The `terraform` subcommand that's run, e.g., `init`, `apply`, `plan`, `destroy`, etc.
  - `mode`: The execution mode of the Terraform CLI, one of `sync` (so that the CLI was invoked synchronously as part of a reconcile loop), `async` (so that the CLI was invoked asynchronously, the reconciler goroutine will poll and collect results in future).
- `upjet_terraform_active_cli_invocations`:  `subcommand` and `mode`.
  - `subcommand`: The `terraform` subcommand that's run, e.g., `init`, `apply`, `plan`, `destroy`, etc.
  - `mode`: The execution mode of the Terraform CLI, one of `sync` (so that the CLI was invoked synchronously as part of a reconcile loop), `async` (so that the CLI was invoked asynchronously, the reconciler goroutine will poll and collect results in future).
- `upjet_terraform_running_processes`: `type`
  - `type`: Either `cli` for Terraform CLI (the `terraform` process) processes or `provider` for the Terraform provider processes. Please note that this is a best effort metric that may not be able to precisely catch & report all relevant processes. We may, in the future, improve this if needed by for example watching the `fork` system calls. But currently, it may prove to be useful to watch rouge Terraform provider processes.
- `upjet_resource_ttr`: `group`, `version`, `kind`
  - `group`, `version`, `kind` labels record the [API group, version and kind](https://kubernetes.io/docs/reference/using-api/api-concepts/) for the managed resource, whose [time-to-readiness](https://github.com/crossplane/terrajet/issues/55#issuecomment-929494212) measurement is captured.

### Notes on the concurrency-related changes:
1. `terraform.Operation.MarkStart` now atomically checks for ongoing async operations and reserves the "operation slot" (by recording the start time): We were previously checking whether there's an ongoing async operation in a critical section, exiting out of the critical section and then entering another section where we do the reservation like follows:
```go
	if w.LastOperation.IsRunning() {
		return errors.Errorf("%s operation that started at %s is still running", w.LastOperation.Type, w.LastOperation.StartTime().String())
	}
	w.LastOperation.MarkStart("apply")
```
From a theoretical perspective this does not look right but in fact, [the above section is never executed by two concurrent goroutines (on the same operation)](https://github.com/kubernetes/client-go/blob/bfa72fd2d36785ecf275bfcb138cfe881fa46bb1/util/workqueue/doc.go#L20) and thus is safe, as long as the controller-runtime behaves according to this assumption. But nevertheless, this PR proposes to change `MarkStart` so that it atomically checks and reserves the slot because:
  - It's conceptually simpler. The relevant section above now looks like:
```golang
	if !w.LastOperation.MarkStart("apply") {
		return errors.Errorf("%s operation that started at %s is still running", w.LastOperation.Type, w.LastOperation.StartTime().String())
	}
``` 
  - It's easier to reason about and to prove its correctness as we align with the theory. You don't need to make assumptions about how the controller-runtime behaves and in the very unlikely case that this assumption does not hold (because of a bug in client-go or controller-runtime, or because of a change in upjet), we will still be safe. 

2. `terraform.Operation.{Start,End}Time` no longer return pointers that could potentially be used to modify the shared state outside of critical sections: Not sure if this has practical implications but again from a theoretical point of view, it's good practice to read the data in a critical section, make a copy of it, and return that snapshot copy so that its clients will not have a chance to modify the shared state outside of a critical section. 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] We'd also like to document what custom metrics are exposed from upjet runtime
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
10 `userpool.cognitoidp` resources from `upbound/provider-aws` were provisioned, reconciled with a poll interval of 1m twice after acquiring the `Ready=True` status condition, and they were finally destroyed. Here are some sample screenshots from the Prometheus UI:

- `upjet_terraform_active_cli_invocations` gauge metric showing the sync & async `terraform init/apply/plan/destroy` invocations:
<img width="3000" alt="image" src="https://user-images.githubusercontent.com/9376684/223296539-94e7d634-58b0-4d3f-942e-8b857eb92ef7.png">

- `upjet_terraform_running_processes` gauge metric showing both `cli` and `provider` labels:
<img width="2999" alt="image" src="https://user-images.githubusercontent.com/9376684/223297575-18c2232e-b5af-4cc1-916a-d61fe5dfb527.png">

- `upjet_terraform_cli_duration` histogram metric, showing average Terraform CLI running times for the last 5m:
<img width="2993" alt="image" src="https://user-images.githubusercontent.com/9376684/223299401-8f128b74-8d9c-4c82-86c5-26870385bee7.png">

The medians (0.5-quantiles) for these observations aggregated by the mode and Terraform subcommand being invoked:
<img width="2999" alt="image" src="https://user-images.githubusercontent.com/9376684/223300766-c1adebb9-bd19-4a38-9941-116185d8d39f.png">

- `upjet_resource_ttr` histogram metric, showing average resource TTR for the last 10m:
<img width="2999" alt="image" src="https://user-images.githubusercontent.com/9376684/223309711-edef690e-2a59-419b-bb93-8f837496bec8.png">

The median (0.5-quantile) for these TTR observations:
<img width="3002" alt="image" src="https://user-images.githubusercontent.com/9376684/223309727-d1a0f4e2-1ed2-414b-be67-478a0575ee49.png">



<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
