### PR TITLE
Add migration.PlanGeneratorOption to configure a PlanGenerator

### DIFF
--- a/pkg/migration/plan_generator.go
+++ b/pkg/migration/plan_generator.go
@@ -94,6 +94,14 @@ func WithErrorOnInvalidPatchSchema(e bool) PlanGeneratorOption {
 	}
 }
 
+// WithSkipGVKs configures the set of GVKs to skip for conversion
+// during a migration.
+func WithSkipGVKs(gvk ...schema.GroupVersionKind) PlanGeneratorOption {
+	return func(pg *PlanGenerator) {
+		pg.SkipGVKs = gvk
+	}
+}
+
 // PlanGenerator generates a migration.Plan reading the manifests available
 // from `source`, converting managed resources and compositions using the
 // available `migration.Converter`s registered in the `registry` and
@@ -109,6 +117,12 @@ type PlanGenerator struct {
 	// an error is encountered while checking the conformance of a patch
 	// statement against the migration source or the migration target.
 	ErrorOnInvalidPatchSchema bool
+	// GVKs of managed resources that
+	// should be skipped for conversion during the migration, if no
+	// converters are registered for them. If any of the GVK components
+	// is left empty, it will be a wildcard component.
+	// Exact matching with an empty group name is not possible.
+	SkipGVKs []schema.GroupVersionKind
 }
 
 // NewPlanGenerator constructs a new PlanGenerator using the specified
@@ -375,7 +389,21 @@ func (pg *PlanGenerator) convertComposition(o UnstructuredWithMetadata) (*Unstru
 	}, isConverted, nil
 }
 
+func (pg *PlanGenerator) isGVKSkipped(sourceGVK schema.GroupVersionKind) bool {
+	for _, gvk := range pg.SkipGVKs {
+		if (len(gvk.Group) == 0 || gvk.Group == sourceGVK.Group) &&
+			(len(gvk.Version) == 0 || gvk.Version == sourceGVK.Version) &&
+			(len(gvk.Kind) == 0 || gvk.Kind == sourceGVK.Kind) {
+			return true
+		}
+	}
+	return false
+}
+
 func (pg *PlanGenerator) setDefaultsOnTargetTemplate(sourceName *string, sourceNameUsed *bool, gvkSource, gvkTarget schema.GroupVersionKind, target *xpv1.ComposedTemplate, patchSets []xpv1.PatchSet, convertedPS []string) error {
+	if pg.isGVKSkipped(gvkSource) {
+		return nil
+	}
 	// remove invalid patches that do not conform to the migration target's schema
 	if err := pg.removeInvalidPatches(gvkSource, gvkTarget, patchSets, target, convertedPS); err != nil {
 		return errors.Wrap(err, "failed to set the defaults on the migration target composed template")


### PR DESCRIPTION
<!--
Thank you for helping to improve Upjet!

Please read through https://git.io/fj2m9 if this is your first time opening a
Upjet pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Upjet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Depends on: #153 

This PR introduces the `migration.PlanGeneratorOption` to configure a `PlanGenerator` in the migrators. Currently, the available configuration options are:
- `migration.WithErrorOnInvalidPatchSchema`: The migrators will now, by default, not error if issues are encountered while doing a patch schema check against the migration sources & targets and will exclude the patches in the migration target `ComposedTemplate`s after logging the issues. A migrator can revert back to the previous behavior by setting this option on the `PlanGenerator`.
- `migration.WithSkipGVKs`: Allows the migrators to configure a list of GVKs that will not be converted during a migration. Wildcard GVKs can be specified by either leaving the API group, version or kind empty. For example, if the kind of a GVK in the skip list is empty, then all kinds in the specified GV will be skipped. List of skipped GVKs override any converters registered with the `PlanGenerator`'s registry, i.e., even if there's a converter registered for a GVK and the GVK is also in the skip list, then the converter will *not* be run. Resources associated with skipped GVKs are included in the generated migration resources with no further checks or filtering.

This PR also fixes an issue observed when a resource type containing a nested `runtime.RawExtension` field is being migrated. Migration now continues without any further checks on `runtime.RawExtension`s. Currently, the framework just traverses the type hierarchy and being able to follow the structure specified by the `RawExtension` would require us to take the actual values into consideration so initially we just stop checking and filtering at the level a `RawExtension` is encountered.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Manually validated against a migrator converting provider-kubernetes `Object`s. `Object`s have a `runtime.RawExtension` at path `spec.forProvider.manifest`.

[contribution process]: https://git.io/fj2m9
