### PR TITLE
Add config.Resource.Path to support configuring plural names of generated resources

### DIFF
--- a/pkg/config/resource.go
+++ b/pkg/config/resource.go
@@ -301,4 +301,9 @@ type Resource struct {
 	// MetaResource is the metadata associated with the resource scraped from
 	// the Terraform registry.
 	MetaResource *registry.Resource
+
+	// Path is the resource path for the API server endpoint. It defaults to
+	// the plural name of the generated CRD. Overriding this sets both the
+	// path and the plural name for the generated CRD.
+	Path string
 }

--- a/pkg/pipeline/crd.go
+++ b/pkg/pipeline/crd.go
@@ -90,6 +90,7 @@ func (cg *CRDGenerator) Generate(cfg *config.Resource) (string, error) {
 			"Kind":            cfg.Kind,
 			"ForProviderType": gen.ForProviderType.Obj().Name(),
 			"AtProviderType":  gen.AtProviderType.Obj().Name(),
+			"Path":            cfg.Path,
 		},
 		"Provider": map[string]string{
 			"ShortName": cg.ProviderShortName,

--- a/pkg/pipeline/templates/crd_types.go.tmpl
+++ b/pkg/pipeline/templates/crd_types.go.tmpl
@@ -33,7 +33,7 @@ type {{ .CRD.Kind }}Status struct {
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,{{ .Provider.ShortName }}}
+// +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,{{ .Provider.ShortName }}}{{ if .CRD.Path }},path={{ .CRD.Path }}{{ end }}
 type {{ .CRD.Kind }} struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
<!--
Thank you for helping to improve Upjet!

Please read through https://git.io/fj2m9 if this is your first time opening a
Upjet pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Upjet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Manually tested on `upbound/provider-aws` [PR #648](https://github.com/upbound/provider-aws/pull/648).

[contribution process]: https://git.io/fj2m9
