### PR TITLE
Do not add tags to spec when ObserveOnly

### DIFF
--- a/pkg/config/resource.go
+++ b/pkg/config/resource.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/fieldpath"
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	xpresource "github.com/crossplane/crossplane-runtime/pkg/resource"
@@ -225,6 +226,11 @@ func NewTagger(kube client.Client, fieldName string) *Tagger {
 
 // Initialize is a custom initializer for setting external tags
 func (t *Tagger) Initialize(ctx context.Context, mg xpresource.Managed) error {
+	if mg.GetManagementPolicy() == xpv1.ManagementObserveOnly {
+		// We don't want to add tags to the spec.forProvider if the resource is
+		// in ObserveOnly mode.
+		return nil
+	}
 	paved, err := fieldpath.PaveObject(mg)
 	if err != nil {
 		return err


### PR DESCRIPTION
### Description of your changes

We should not add default tags to the spec of the managed resources when the management policy is set as `ObserveOnly` as we are only observing the resource in read-only mode.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Together with https://github.com/upbound/provider-aws/pull/672

Before this PR:

```yaml
apiVersion: rds.aws.upbound.io/v1beta1
kind: Instance
metadata:
  ...
spec:
  deletionPolicy: Delete
  forProvider:
    region: us-west-1
    tags:
      crossplane-kind: instance.rds.aws.upbound.io
      crossplane-name: rds-observe-only
      crossplane-providerconfig: default
  managementPolicy: ObserveOnly
  providerConfigRef:
    name: default
  writeConnectionSecretToRef:
    name: example-dbinstance-out
    namespace: default
status:
  atProvider:
    ...
```

With this PR:

```yaml
```yaml
apiVersion: rds.aws.upbound.io/v1beta1
kind: Instance
metadata:
  ...
spec:
  deletionPolicy: Delete
  forProvider:
    region: us-west-1
  managementPolicy: ObserveOnly
  providerConfigRef:
    name: default
  writeConnectionSecretToRef:
    name: example-dbinstance-out
    namespace: default
status:
  atProvider:
    ...
```

[contribution process]: https://git.io/fj2m9
