### PR TITLE
Add ToLower & ToUpper template functions for config.TemplatedStringAsIdentifier

### DIFF
--- a/pkg/config/externalname_test.go
+++ b/pkg/config/externalname_test.go
@@ -223,6 +223,42 @@ func TestTemplatedGetIDFn(t *testing.T) {
 				id: "olala/paramval:myname/configval",
 			},
 		},
+		"TemplateFunctionToLower": {
+			reason: "Should work with a call of ToLower.",
+			args: args{
+				tmpl:         "olala/{{ .parameters.ola | ToLower }}:{{ .external_name }}/{{ .setup.configuration.oma | ToLower }}",
+				externalName: "myname",
+				parameters: map[string]any{
+					"ola": "ALL_CAPITAL",
+				},
+				setup: map[string]any{
+					"configuration": map[string]any{
+						"oma": "CamelCase",
+					},
+				},
+			},
+			want: want{
+				id: "olala/all_capital:myname/camelcase",
+			},
+		},
+		"TemplateFunctionToUpper": {
+			reason: "Should work with a call of ToUpper.",
+			args: args{
+				tmpl:         "olala/{{ .parameters.ola | ToUpper }}:{{ .external_name }}/{{ .setup.configuration.oma | ToUpper }}",
+				externalName: "myname",
+				parameters: map[string]any{
+					"ola": "all_small",
+				},
+				setup: map[string]any{
+					"configuration": map[string]any{
+						"oma": "CamelCase",
+					},
+				},
+			},
+			want: want{
+				id: "olala/ALL_SMALL:myname/CAMELCASE",
+			},
+		},
 	}
 	for n, tc := range cases {
 		t.Run(n, func(t *testing.T) {


### PR DESCRIPTION
<!--
Thank you for helping to improve Upjet!

Please read through https://git.io/fj2m9 if this is your first time opening a
Upjet pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Upjet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This PR adds `ToLower` and `ToUpper` template functions that can be used in the template body passed to [`config.TemplatedStringAsIdentifier`](https://github.com/upbound/upjet/blob/1c48474d6fadda31377d880d0b79d554e085bedc/pkg/config/externalname.go#L92). With these template functions, it will be possible to specify an external-name configuration such as the following:
```go
config.TemplatedStringAsIdentifier("", "arn:aws:network-firewall:{{ .setup.configuration.region }}:{{ .setup.client_metadata.account_id }}:{{ .parameters.type | ToLower }}-rulegroup/{{ .external_name }}"),
```
, where the value of the `type` parameter will be converted to lower case and used as a component while constructing the Terraform ID.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Tested manually in the context of https://github.com/upbound/provider-aws/pull/661.

[contribution process]: https://git.io/fj2m9
