### PR TITLE
Deprecate config.BasePackages.Controller in favor of ControllerMap

### DIFF
--- a/pkg/config/common.go
+++ b/pkg/config/common.go
@@ -13,6 +13,19 @@ import (
 	tjname "github.com/upbound/upjet/pkg/types/name"
 )
 
+const (
+	// PackageNameConfig is the name of the provider subpackage that contains
+	// the base resources (e.g., ProviderConfig, ProviderConfigUsage,
+	// StoreConfig. etc.).
+	// TODO: we should be careful that there may also exist short groups with
+	// these names. We can consider making these configurable by the provider
+	// maintainer.
+	PackageNameConfig = "config"
+	// PackageNameMonolith is the name of the backwards-compatible
+	// provider subpackage that contains the all the resources.
+	PackageNameMonolith = "monolith"
+)
+
 // Commonly used resource configurations.
 var (
 	DefaultBasePackages = BasePackages{
@@ -21,9 +34,14 @@ var (
 			"apis/v1alpha1",
 			"apis/v1beta1",
 		},
+		//nolint:staticcheck
 		Controller: []string{
 			// Default package for ProviderConfig controllers
 			"internal/controller/providerconfig",
+		},
+		ControllerMap: map[string]string{
+			// Default package for ProviderConfig controllers
+			"internal/controller/providerconfig": PackageNameConfig,
 		},
 	}
 

--- a/pkg/config/provider.go
+++ b/pkg/config/provider.go
@@ -40,11 +40,15 @@ func (cc ResourceConfiguratorChain) Configure(r *Resource) {
 	}
 }
 
-// BasePackages keeps lists of base packages that needs to be registered as API
+// BasePackages keeps lists of packages that needs to be registered as API
 // and controllers. Typically, we expect to see ProviderConfig packages here.
+// These APIs and controllers belong to non-generated (manually maintained)
+// resources.
 type BasePackages struct {
 	APIVersion []string
-	Controller []string
+	// Deprecated: Use ControllerMap instead.
+	Controller    []string
+	ControllerMap map[string]string
 }
 
 // Provider holds configuration for a provider to be generated with Upjet.

--- a/pkg/pipeline/setup.go
+++ b/pkg/pipeline/setup.go
@@ -15,6 +15,7 @@ import (
 	"github.com/muvaf/typewriter/pkg/wrapper"
 	"github.com/pkg/errors"
 
+	"github.com/upbound/upjet/pkg/config"
 	"github.com/upbound/upjet/pkg/pipeline/templates"
 )
 
@@ -48,7 +49,7 @@ func (sg *ProviderGenerator) Generate(versionPkgMap map[string][]string, mainTem
 		t = tmpl
 	}
 	if t == nil {
-		return errors.Wrap(sg.generate("", versionPkgMap[monolithPackageName]), "failed to generate the controller setup file")
+		return errors.Wrap(sg.generate("", versionPkgMap[config.PackageNameMonolith]), "failed to generate the controller setup file")
 	}
 	for g, versionPkgList := range versionPkgMap {
 		if err := sg.generate(g, versionPkgList); err != nil {


### PR DESCRIPTION
<!--
Thank you for helping to improve Upjet!

Please read through https://git.io/fj2m9 if this is your first time opening a
Upjet pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Upjet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
`config.BasePackages.Controller` does not convey which subpackage a controller should be added to. One option would be to rely on a path component of the controller (e.g., if the controller being registered is `internal/controller/eks/clusterauth`, then the subpackage could be `eks` as deduced from the path) but the proposed `ControllerMap` makes this more explicit and makes it easier to override/remap if needed. 

The proposed ControllerMap is a map from the controller's path to the subpackage name for the controller. `Controller` array is also deprecated in favor of `ControllerMap`.

Note: The deprecated `BasePackages.Controller` API still exists and behaves exactly as is (if not, it will be treated as a bug), and the new `BasePackages.ControllerMap` API is an optional one. In summary, this PR is intended to be backwards-compatible.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
Tested via https://github.com/upbound/provider-aws/pull/680.
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
