### PR TITLE
Fixes and improvements in smaller provider migration docs

### DIFF
--- a/docs/sp-migration-conf.md
+++ b/docs/sp-migration-conf.md
@@ -6,7 +6,7 @@
 ```bash
 kubectl get managed -o yaml > backup-mrs.yaml
 kubectl get composite -o yaml > backup-composites.yaml
-kubectl get claim -n $NAMESPACE -o yaml > backup-claims.yaml
+kubectl get claim --all-namespaces -o yaml > backup-claims.yaml
 ```
 
 2. Update deletion policy to `Orphan`:
@@ -30,7 +30,7 @@ kubectl get managed --no-headers -o jsonpath='{range .items[*]}{.apiVersion}{"\n
 do
   service=$(echo "${line}" | cut -d. -f1)
   provider=$(echo "${line}" | cut -d. -f2)
-  if [[ ${provider} == "upbound" ]]; then
+  if [ "${provider}" = "upbound" ]; then
     # azure.upbound.io is an exception where apiVersion does not contain the service name
     # we have those resources in the family package
     provider="azure"
@@ -41,12 +41,12 @@ do
     filename="sp-manual.yaml"
     providername="${provider}-${sp}"
     
-    if [[ "${sp}" == "config" ]] || [[ "${sp}" == "azure" ]]; then
-    # azure.upbound.io is an exception where apiVersion does not contain the service name
-    # we have those resources in the family package
-    providername="family-$provider"
-    filename="sp-family-manual.yaml"
-  fi
+    if [ "${sp}" = "config" ] || [ "${sp}" = "azure" ]; then
+      # azure.upbound.io is an exception where apiVersion does not contain the service name
+      # we have those resources in the family package
+      providername="family-$provider"
+      filename="sp-family-manual.yaml"
+    fi
     if ! cat "${filename}" | grep provider-${providername}:${version} > /dev/null; then
     echo "apiVersion: pkg.crossplane.io/v1
 kind: Provider
@@ -61,7 +61,7 @@ spec:
 done
 ```
 
-4. Install config providers with `revisionActivationPolicy: Manual`:
+4. Install family providers with `revisionActivationPolicy: Manual`:
 
 Verify that `sp-family-manual.yaml` files are generated with the correct content
 
@@ -89,7 +89,7 @@ Verify that `sp-manual.yaml` files are generated with the correct content
 cat sp-manual.yaml
 ```
 
-Install the family provider
+Install the smallers providers
 
 ```bash
 kubectl apply -f sp-manual.yaml

--- a/docs/sp-migration-mr.md
+++ b/docs/sp-migration-mr.md
@@ -27,7 +27,7 @@ kubectl get managed --no-headers -o jsonpath='{range .items[*]}{.apiVersion}{"\n
 do
   service=$(echo "${line}" | cut -d. -f1)
   provider=$(echo "${line}" | cut -d. -f2)
-  if [[ ${provider} == "upbound" ]]; then
+  if [ "${provider}" = "upbound" ]; then
     # azure.upbound.io is an exception where apiVersion does not contain the service name
     # we have those resources in the family package
     provider="azure"
@@ -38,12 +38,12 @@ do
     filename="sp-manual.yaml"
     providername="${provider}-${sp}"
     
-    if [[ "${sp}" == "config" ]] || [[ "${sp}" == "azure" ]]; then
-    # azure.upbound.io is an exception where apiVersion does not contain the service name
-    # we have those resources in the family package
-    providername="family-$provider"
-    filename="sp-family-manual.yaml"
-  fi
+    if [ "${sp}" = "config" ] || [ "${sp}" = "azure" ]; then
+      # azure.upbound.io is an exception where apiVersion does not contain the service name
+      # we have those resources in the family package
+      providername="family-$provider"
+      filename="sp-family-manual.yaml"
+    fi
     if ! cat "${filename}" | grep provider-${providername}:${version} > /dev/null; then
     echo "apiVersion: pkg.crossplane.io/v1
 kind: Provider
@@ -58,22 +58,22 @@ spec:
 done
 ```
 
-4. Install config providers with `revisionActivationPolicy: Manual`:
+4. Install family providers with `revisionActivationPolicy: Manual`:
 
 
-Verify that `sp-config-manual.yaml` files are generated with the correct content
-
-```bash
-cat sp-config-manual.yaml
-```
-
-Install the config provider(s)
+Verify that `sp-family-manual.yaml` files are generated with the correct content
 
 ```bash
-kubectl apply -f sp-config-manual.yaml
+cat sp-family-manual.yaml
 ```
 
-Make sure the config provider(s) are in `Installed: False` and `Healthy: True` state:
+Install the family provider(s)
+
+```bash
+kubectl apply -f sp-family-manual.yaml
+```
+
+Make sure the family provider(s) are in `Installed: False` and `Healthy: True` state:
 
 ```bash
 kubectl get providers.pkg
@@ -88,7 +88,7 @@ Verify that `sp-manual.yaml` files are generated with the correct content
 cat sp-manual.yaml
 ```
 
-Install the config provider
+Install the smallers providers
 
 ```bash
 kubectl apply -f sp-manual.yaml
@@ -109,9 +109,9 @@ kubectl delete provider.pkg $PROVIDER_NAME
 7. Update smaller providers with `revisionActivationPolicy:Automatic`:
 
 ```bash
-sed 's/revisionActivationPolicy: Manual/revisionActivationPolicy: Automatic/' sp-config-manual.yaml > sp-config-automatic.yaml
+sed 's/revisionActivationPolicy: Manual/revisionActivationPolicy: Automatic/' sp-family-manual.yaml > sp-family-automatic.yaml
 
-kubectl apply -f sp-config-automatic.yaml
+kubectl apply -f sp-family-automatic.yaml
 ```
 
 


### PR DESCRIPTION
### Description of your changes

This PR:
- Fixes `[[: not found` errors for non-bash shells.
- Fixes filename for family provider manifests.
- Uses `--all-namespaces` for backing claims up

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Tested with platform-ref-azure.

[contribution process]: https://git.io/fj2m9
