### PR TITLE
Extend SSOP migration script and process with the local source 

### DIFF
--- a/docs/sp-migration/generate-manifests.sh
+++ b/docs/sp-migration/generate-manifests.sh
@@ -1,8 +1,11 @@
 #!/bin/sh
 set -e
 
+# shellcheck disable=SC2034
 version_aws=v0.37.0
+# shellcheck disable=SC2034
 version_azure=v0.34.0
+# shellcheck disable=SC2034
 version_gcp=v0.34.0
 
 rm -f "sp-manual.yaml" && touch "sp-manual.yaml"
@@ -37,7 +40,8 @@ do
       providername="family-$provider"
       filename="sp-family-manual.yaml"
     fi
-    if ! cat "${filename}" | grep provider-${providername}:${version} > /dev/null; then
+    # shellcheck disable=SC2154
+    if ! grep provider-"${providername}:${version}" "${filename}" > /dev/null; then
     echo "apiVersion: pkg.crossplane.io/v1
 kind: Provider
 metadata:

--- a/docs/sp-migration/generate-manifests.sh
+++ b/docs/sp-migration/generate-manifests.sh
@@ -12,7 +12,7 @@ rm -f "sp-manual.yaml" && touch "sp-manual.yaml"
 rm -f "sp-family-manual.yaml" && touch "sp-family-manual.yaml"
 
 if [ -n "$CONF_PATH" ]; then
-  echo "Generating manifests from $CONF_PATH"
+  echo "Generating manifests from $CONF_PATH. No runtime Managed Resources will be included"
   apiGroups=$(grep -rh apiVersion: "$CONF_PATH" | grep -E '(aws|gcp|azure).upbound.io' | sort | uniq | tr -d '[:blank:]'| cut -d ":" -f 2)
 else
   echo "Generating manifests from current cluster"

--- a/docs/sp-migration/generate-manifests.sh
+++ b/docs/sp-migration/generate-manifests.sh
@@ -7,7 +7,16 @@ version_gcp=v0.34.0
 
 rm -f "sp-manual.yaml" && touch "sp-manual.yaml"
 rm -f "sp-family-manual.yaml" && touch "sp-family-manual.yaml"
-kubectl get managed --no-headers -o jsonpath='{range .items[*]}{.apiVersion}{"\n"}{end}' | grep -E '(aws|gcp|azure).upbound.io' | sort | uniq | while read -r line
+
+if [ -n "$CONF_PATH" ]; then
+  echo "Generating manifests from $CONF_PATH"
+  apiGroups=$(grep -rh apiVersion: "$CONF_PATH" | grep -E '(aws|gcp|azure).upbound.io' | sort | uniq | tr -d '[:blank:]'| cut -d ":" -f 2)
+else
+  echo "Generating manifests from current cluster"
+  apiGroups=$(kubectl get managed --no-headers -o jsonpath='{range .items[*]}{.apiVersion}{"\n"}{end}' | grep -E '(aws|gcp|azure).upbound.io' | sort | uniq)
+fi
+
+echo "$apiGroups"| while read -r line
 do
   service=$(echo "${line}" | cut -d. -f1)
   provider=$(echo "${line}" | cut -d. -f2)

--- a/docs/sp-migration/sp-migration-conf.md
+++ b/docs/sp-migration/sp-migration-conf.md
@@ -25,7 +25,7 @@ export KUBECONFIG=<path of the Kubeconfig file>
 ```
 
 Alternatively, you can generate the provider manifests out of the local
-Configuration files
+Configuration files. No runtime Managed Resources will be included in this case.
 
 ```bash
 export CONF_PATH=<root path of the configuration files>

--- a/docs/sp-migration/sp-migration-conf.md
+++ b/docs/sp-migration/sp-migration-conf.md
@@ -24,6 +24,14 @@ export KUBECONFIG=<path of the Kubeconfig file>
 ./generate-manifests.sh
 ```
 
+Alternatively, you can generate the provider manifests out of the local
+Configuration files
+
+```bash
+export CONF_PATH=<root path of the configuration files>
+./generate-manifests.sh
+```
+
 4. Install family providers with `revisionActivationPolicy: Manual`:
 
 Verify that `sp-family-manual.yaml` files are generated with the correct content


### PR DESCRIPTION
<!--
Thank you for helping to improve Upjet!

Please read through https://git.io/fj2m9 if this is your first time opening a
Upjet pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Extend SSOP migration script and process with the local source:

* Extend `generate-manifests.sh` to generate SSOP installation manifests
out of local Configuration files/Compositions
* Document it by extending existing migration step

Additionally, Comply with `shellcheck`:

* Optimize grepping
* Skip checks in places where `shellcheck `can't figure out dynamic `eval`
  and provides false negatives

Signed-off-by: Yury Tsarev <yury@upbound.io>

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

```
./generate-manifests.sh
Generating manifests from current cluster
```

```
export CONF_PATH=~/new-compositions
./generate-manifests.sh
Generating manifests from ./new-compositions
```

Checked that in both cases the script generates valid installation manifests