### PR TITLE
Remove the command related to the sample configuration directory

### DIFF
--- a/docs/generating-a-provider.md
+++ b/docs/generating-a-provider.md
@@ -116,8 +116,6 @@ example organization name to be used.
    mkdir config/repository
    # Create custom configuration directory for whole branch group
    mkdir config/branch
-   # remove the sample directory which was a configuration in the template
-   rm -rf config/null
    ```
 
    ```bash


### PR DESCRIPTION
### Description of your changes

This PR includes removing the command related to the sample configuration directory from New Provider Generation Guide

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.


[contribution process]: https://git.io/fj2m9
