### PR TITLE
Add an example Smaller Provider migration plan

### DIFF
--- a/pkg/migration/errors.go
+++ b/pkg/migration/errors.go
@@ -1,0 +1,31 @@
+// Copyright 2023 Upbound Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migration
+
+import "fmt"
+
+type errUnsupportedStepType struct {
+	planStep Step
+}
+
+func (e errUnsupportedStepType) Error() string {
+	return fmt.Sprintf("executor does not support steps of type %q in step: %s", e.planStep.Type, e.planStep.Name)
+}
+
+func NewUnsupportedStepTypeError(s Step) error {
+	return errUnsupportedStepType{
+		planStep: s,
+	}
+}

--- a/pkg/migration/executor.go
+++ b/pkg/migration/executor.go
@@ -1,0 +1,67 @@
+package migration
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/pkg/errors"
+	"k8s.io/utils/exec"
+
+	"github.com/crossplane/crossplane-runtime/pkg/logging"
+)
+
+type ForkExecutor struct {
+	executor exec.Interface
+	logger   logging.Logger
+}
+
+// ForkExecutorOption allows you to configure ForkExecutor objects.
+type ForkExecutorOption func(executor *ForkExecutor)
+
+// WithLogger sets the logger of ForkExecutor.
+func WithLogger(l logging.Logger) ForkExecutorOption {
+	return func(e *ForkExecutor) {
+		e.logger = l
+	}
+}
+
+// WithExecutor sets the executor of ForkExecutor.
+func WithExecutor(e exec.Interface) ForkExecutorOption {
+	return func(fe *ForkExecutor) {
+		fe.executor = e
+	}
+}
+
+// NewForkExecutor returns a new ForkExecutor with executor
+func NewForkExecutor(opts ...ForkExecutorOption) *ForkExecutor {
+	fe := &ForkExecutor{
+		logger: logging.NewNopLogger(),
+	}
+	for _, f := range opts {
+		f(fe)
+	}
+	return fe
+}
+
+func (f ForkExecutor) Init(config any) error {
+	return nil
+}
+
+func (f ForkExecutor) Step(s Step, ctx any) (any, error) {
+	if s.Type != StepTypeExec {
+		return nil, errors.Wrap(NewUnsupportedStepTypeError(s), "expected step type is Exec")
+	}
+
+	cmd := f.executor.Command(s.Exec.Command, s.Exec.Args...)
+	cmd.SetEnv(os.Environ())
+
+	if err := cmd.Run(); err != nil {
+		return nil, errors.Wrap(err, fmt.Sprintf("could not execute step %s", s.Name))
+	}
+
+	return nil, nil
+}
+
+func (f ForkExecutor) Destroy() error {
+	return nil
+}

--- a/pkg/migration/executor_test.go
+++ b/pkg/migration/executor_test.go
@@ -1,0 +1,107 @@
+package migration
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/pkg/errors"
+	k8sExec "k8s.io/utils/exec"
+	testingexec "k8s.io/utils/exec/testing"
+
+	"github.com/crossplane/crossplane-runtime/pkg/test"
+)
+
+var (
+	backupManagedStep = Step{
+		Name: "backup-managed-resources",
+		Type: StepTypeExec,
+		Exec: &ExecStep{
+			Command: "sh",
+			Args:    []string{"-c", "kubectl get managed -o yaml"},
+		},
+	}
+
+	wrongCommand = Step{
+		Name: "wrong-command",
+		Type: StepTypeExec,
+		Exec: &ExecStep{
+			Command: "sh",
+			Args:    []string{"-c", "nosuchcommand"},
+		},
+	}
+
+	wrongStepType = Step{
+		Name: "wrong-step-type",
+		Type: StepTypeDelete,
+	}
+)
+
+var errorWrongCommand = errors.New("exit status 127")
+
+func newFakeExec(err error) *testingexec.FakeExec {
+	return &testingexec.FakeExec{
+		CommandScript: []testingexec.FakeCommandAction{
+			func(_ string, _ ...string) k8sExec.Cmd {
+				return &testingexec.FakeCmd{
+					RunScript: []testingexec.FakeAction{
+						func() ([]byte, []byte, error) {
+							return nil, nil, err
+						},
+					},
+				}
+			},
+		},
+	}
+}
+
+func TestForkExecutorStep(t *testing.T) {
+	type args struct {
+		step     Step
+		fakeExec *testingexec.FakeExec
+	}
+	type want struct {
+		err error
+	}
+
+	cases := map[string]struct {
+		args
+		want
+	}{
+		"Success": {
+			args: args{
+				step:     backupManagedStep,
+				fakeExec: &testingexec.FakeExec{DisableScripts: true},
+			},
+			want: want{
+				nil,
+			},
+		},
+		"Failure": {
+			args: args{
+				step:     wrongCommand,
+				fakeExec: newFakeExec(errorWrongCommand),
+			},
+			want: want{
+				errors.Wrap(errorWrongCommand, "could not execute step wrong-command"),
+			},
+		},
+		"WrongStepType": {
+			args: args{
+				step: wrongStepType,
+			},
+			want: want{
+				errors.Wrap(NewUnsupportedStepTypeError(wrongStepType), "expected step type is Exec"),
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			fe := NewForkExecutor(WithExecutor(tc.fakeExec))
+			_, err := fe.Step(tc.step, nil)
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nStep(...): -want error, +got error:\n%s", name, diff)
+			}
+		})
+	}
+}

--- a/pkg/migration/testdata/plan/generated/sp_migration_plan.yaml
+++ b/pkg/migration/testdata/plan/generated/sp_migration_plan.yaml
@@ -1,0 +1,159 @@
+# Expected Parameters:
+#   Monolith provider name
+#   Configuration name
+#   Configuration registry/org
+#   Configuration package path
+#   Configuration example path
+#   Configuration version
+#   New configuration version
+
+spec:
+  steps:
+    - exec:
+        command: sh
+        args: -c 'kubectl get managed -o yaml > backup/managed-resources.yaml'
+      name: backup-managed-resources
+      type: Exec
+
+    - exec:
+        command: sh
+        args: -c 'kubectl get composite -o yaml > backup/composite-resources.yaml'
+      name: backup-composite-resources
+      type: Exec
+
+    - exec:
+        command: sh
+        args: -c 'kubectl get claim --all-namespaces -o yaml > backup/claim-resources.yaml'
+      name: backup-claim-resources
+      type: Exec
+
+    - patch:
+        type: merge
+        files:
+          - deletion-policy-orphan/sample-vpc.vpcs.fakesourceapi.yaml
+      name: deletion-policy-orphan
+      type: Patch
+
+    # 'spec.revisionActivationPolicy= "Manual"'
+    - apply:
+        files:
+          - create-new-sp/sample-smaller-provider.provider-family-aws.yaml
+      name: create-new-sp
+      type: Apply
+
+    - exec:
+        command: sh
+        args: -c 'kubectl wait provider.pkg provider-family-aws --for condition=Healthy'
+      name: wait-for-healthy
+      type: Exec
+
+    # 'spec.revisionActivationPolicy= "Manual"'
+    - apply:
+        files:
+          - create-new-sp/sample-smaller-provider.provider-aws-ec2.yaml
+      name: create-new-sp
+      type: Apply
+
+    - exec:
+        command: sh
+        args: -c 'kubectl wait provider.pkg provider-aws-ec2 --for condition=Healthy'
+      name: wait-for-healthy
+      type: Exec
+
+    # 'spec.skipDependencyResolution= true'
+    - patch:
+        type: merge
+        files:
+          - skip-dependency-true/configuration.yaml
+      name: skip-dependency-true
+      type: Patch
+
+    - apply:
+        files:
+          - remove-monolith-provider-dependency/lock.yaml
+      name: remove-monolith-provider-dependency
+      type: Apply
+
+    - delete:
+        options:
+          finalizerPolicy: Remove
+        resources:
+          - group: pkg.crossplane.io
+            kind: Provider
+            name: upbound-provider-aws
+            version: v1
+      name: delete-monolith-provider
+      type: Delete
+
+    - patch:
+        type: merge
+        files:
+          - revision-activation-automatic/sample-smaller-provider.provider-family-aws.yaml
+      name: revision-activation-automatic
+      type: Patch
+
+    - exec:
+        command: sh
+        args: -c 'kubectl wait provider.pkg provider-family-aws --for condition=Installed'
+      name: wait-for-installed
+      type: Exec
+
+    - patch:
+        type: merge
+        files:
+          - revision-activation-automatic/sample-smaller-provider.provider-aws-ec2.yaml
+      name: revision-activation-automatic
+      type: Patch
+
+    - exec:
+        command: sh
+        args: -c 'kubectl wait provider.pkg provider-aws-ec2 --for condition=Installed'
+      name: wait-for-installed
+      type: Exec
+
+    - patch:
+        type: merge
+        files:
+          - edit-configurations/platform-ref-aws.configurations.meta.pkg.crossplane.io_v1.yaml
+      name: edit-configurations
+      type: Patch
+
+    - exec:
+        command: sh
+        args:
+          - -c 'up xpkg build --name test-smaller-provider-migration.xpkg --package-root=package --examples-root=examples'
+      name: build-configuration
+      type: Exec
+
+    - exec:
+        command: sh
+        args:
+          - -c 'up xpkg push ${ORG}/${PLATFORM}:${TAG} -f package/test-smaller-provider-migration.xpkg'
+      name: push-configuration
+      type: Exec
+
+    # 'spec.package="docker.io/myorg/test-smaller-provider-migration:v0.1.1"'
+    - patch:
+        type: merge
+        files:
+          - update-configuration/configuration.yaml
+      name: update-configuration
+      type: Patch
+
+    # 'spec.skipDependencyResolution= false'
+    - patch:
+        type: merge
+        files:
+          - skip-dependency-false/configuration.yaml
+      name: skip-dependency-false
+      type: Patch
+
+    - patch:
+        type: merge
+        files:
+          - deletion-policy-delete/sample-vpc.vpcs.fakesourceapi.yaml
+      name: deletion-policy-delete
+      type: Patch
+
+version: 0.1.0
+

--- a/pkg/migration/types.go
+++ b/pkg/migration/types.go
@@ -66,6 +66,8 @@ const (
 	StepTypePatch StepType = "Patch"
 	// StepTypeDelete denotes a delete step
 	StepTypeDelete StepType = "Delete"
+	// StepTypeExec executes the command with provided args
+	StepTypeExec StepType = "Exec"
 )
 
 // Step represents a step in the generated migration plan
@@ -83,6 +85,8 @@ type Step struct {
 	// Delete contains the information needed to run an StepTypeDelete step.
 	// Must be set when the Step.Type is StepTypeDelete.
 	Delete *DeleteStep `json:"delete,omitempty"`
+	// Exec contains the information needed to run a StepTypeExec step.
+	Exec *ExecStep `json:"exec,omitempty"`
 }
 
 // ApplyStep represents an apply step in which an array of manifests
@@ -131,6 +135,14 @@ type DeleteOptions struct {
 	// FinalizerPolicy denotes the policy to be used regarding
 	// the managed reconciler's finalizer
 	FinalizerPolicy *FinalizerPolicy `json:"finalizerPolicy,omitempty"`
+}
+
+// ExecStep represents an exec command with its arguments
+type ExecStep struct {
+	// Command is the command to run
+	Command string `json:"command"`
+	// Args is the arguments of the command
+	Args []string `json:"args"`
 }
 
 // GroupVersionKind represents the GVK for an object's kind.


### PR DESCRIPTION
<!--
Thank you for helping to improve Upjet!

Please read through https://git.io/fj2m9 if this is your first time opening a
Upjet pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

This change adds an example configuration migration plan and introduces `Exec` as a new step type. We also implement `ForkExecutor` to run `Exec` steps in our migration plan.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Upjet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

With unit tests and running commands with ForkExecutor. 


<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
