### PR TITLE
Add support for category-based manifest pre-processors

### DIFF
--- a/pkg/migration/configurationmetadata_steps.go
+++ b/pkg/migration/configurationmetadata_steps.go
@@ -46,7 +46,7 @@ func (pg *PlanGenerator) convertConfigurationMetadata(o UnstructuredWithMetadata
 	isConverted := false
 	var conf metav1.Object
 	var err error
-	for _, confConv := range pg.registry.configurationConverters {
+	for _, confConv := range pg.registry.configurationMetaConverters {
 		if confConv.re == nil || confConv.converter == nil || !confConv.re.MatchString(o.Object.GetName()) {
 			continue
 		}

--- a/pkg/migration/converter.go
+++ b/pkg/migration/converter.go
@@ -145,10 +145,12 @@ func FromGroupVersionKind(gvk schema.GroupVersionKind) GroupVersionKind {
 	}
 }
 
-// workaround for:
+// ToComposition converts the specified unstructured.Unstructured to
+// a Crossplane Composition.
+// Workaround for:
 // https://github.com/kubernetes-sigs/structured-merge-diff/issues/230
-func convertToComposition(u map[string]interface{}) (*xpv1.Composition, error) {
-	buff, err := json.Marshal(u)
+func ToComposition(u unstructured.Unstructured) (*xpv1.Composition, error) {
+	buff, err := json.Marshal(u.Object)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to marshal map to JSON")
 	}
@@ -238,6 +240,15 @@ func toProviderPackage(u unstructured.Unstructured) (*xppkgv1.Provider, error) {
 		return nil, errors.Wrap(err, errFromUnstructuredProvider)
 	}
 	return pkg, nil
+}
+
+func getCategory(u unstructured.Unstructured) Category {
+	switch u.GroupVersionKind() {
+	case xpv1.CompositionGroupVersionKind:
+		return CategoryComposition
+	default:
+		return categoryUnknown
+	}
 }
 
 /*func toPackageLock(u unstructured.Unstructured) (*xppkgv1beta1.Lock, error) {

--- a/pkg/migration/converter.go
+++ b/pkg/migration/converter.go
@@ -21,6 +21,7 @@ import (
 	xpmetav1 "github.com/crossplane/crossplane/apis/pkg/meta/v1"
 	xpmetav1alpha1 "github.com/crossplane/crossplane/apis/pkg/meta/v1alpha1"
 	xppkgv1 "github.com/crossplane/crossplane/apis/pkg/v1"
+	xppkgv1beta1 "github.com/crossplane/crossplane/apis/pkg/v1beta1"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -35,9 +36,9 @@ const (
 	errFromUnstructuredConfMeta    = "failed to convert from unstructured.Unstructured to Crossplane Configuration metadata"
 	errFromUnstructuredConfPackage = "failed to convert from unstructured.Unstructured to Crossplane Configuration package"
 	errFromUnstructuredProvider    = "failed to convert from unstructured.Unstructured to Crossplane Provider package"
-	// errFromUnstructuredLock     = "failed to convert from unstructured.Unstructured to Crossplane package lock"
-	errToUnstructured        = "failed to convert from the managed resource type to unstructured.Unstructured"
-	errRawExtensionUnmarshal = "failed to unmarshal runtime.RawExtension"
+	errFromUnstructuredLock        = "failed to convert from unstructured.Unstructured to Crossplane package lock"
+	errToUnstructured              = "failed to convert from the managed resource type to unstructured.Unstructured"
+	errRawExtensionUnmarshal       = "failed to unmarshal runtime.RawExtension"
 
 	errFmtPavedDelete = "failed to delete fieldpath %q from paved"
 )
@@ -251,10 +252,10 @@ func getCategory(u unstructured.Unstructured) Category {
 	}
 }
 
-/*func toPackageLock(u unstructured.Unstructured) (*xppkgv1beta1.Lock, error) {
+func toPackageLock(u unstructured.Unstructured) (*xppkgv1beta1.Lock, error) {
 	lock := &xppkgv1beta1.Lock{}
 	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, lock); err != nil {
 		return nil, errors.Wrap(err, errFromUnstructuredLock)
 	}
 	return lock, nil
-}*/
+}

--- a/pkg/migration/filesystem.go
+++ b/pkg/migration/filesystem.go
@@ -13,6 +13,11 @@ import (
 	sigsyaml "sigs.k8s.io/yaml"
 )
 
+var (
+	_ Source = &FileSystemSource{}
+	_ Target = &FileSystemTarget{}
+)
+
 // FileSystemSource is a source implementation to read resources from filesystem
 type FileSystemSource struct {
 	index int
@@ -62,7 +67,8 @@ func NewFileSystemSource(dir string, opts ...FileSystemSourceOption) (*FileSyste
 		fs.items = append(fs.items, UnstructuredWithMetadata{
 			Object: *u,
 			Metadata: Metadata{
-				Path: path,
+				Path:     path,
+				Category: getCategory(*u),
 			},
 		})
 
@@ -87,6 +93,12 @@ func (fs *FileSystemSource) Next() (UnstructuredWithMetadata, error) {
 		return item, nil
 	}
 	return UnstructuredWithMetadata{}, errors.New("no more elements")
+}
+
+// Reset resets the source so that resources can be reread from the beginning.
+func (fs *FileSystemSource) Reset() error {
+	fs.index = 0
+	return nil
 }
 
 // FileSystemTarget is a target implementation to write/patch/delete resources to file system

--- a/pkg/migration/interfaces.go
+++ b/pkg/migration/interfaces.go
@@ -120,6 +120,11 @@ type Source interface {
 	// Next returns the next resource manifest available or
 	// any errors encountered while reading the next resource manifest.
 	Next() (UnstructuredWithMetadata, error)
+	// Reset resets the Source so that it can read the manifests
+	// from the beginning. There is no guarantee that the Source
+	// will return the same set of manifests or it will return
+	// them in the same order after a reset.
+	Reset() error
 }
 
 // Target is a target where resource manifests can be manipulated
@@ -144,4 +149,15 @@ type Executor interface {
 	// or a step has returned an error, and we would like to stop
 	// executing the plan.
 	Destroy() error
+}
+
+// UnstructuredPreProcessor allows manifests read by the Source
+// to be pre-processed before the converters are run
+// It's not possible to do any conversions via the pre-processors,
+// and they only allow migrators to extract information from
+// the manifests read by the Source before any converters are run.
+type UnstructuredPreProcessor interface {
+	// PreProcess is called for a manifest read by the Source
+	// before any converters are run.
+	PreProcess(u UnstructuredWithMetadata) error
 }

--- a/pkg/migration/kubernetes.go
+++ b/pkg/migration/kubernetes.go
@@ -15,6 +15,10 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
+var (
+	_ Source = &KubernetesSource{}
+)
+
 // KubernetesSource is a source implementation to read resources from Kubernetes
 // cluster.
 type KubernetesSource struct {
@@ -96,6 +100,12 @@ func (ks *KubernetesSource) Next() (UnstructuredWithMetadata, error) {
 		return item, nil
 	}
 	return UnstructuredWithMetadata{}, errors.New("no more elements")
+}
+
+// Reset resets the source so that resources can be reread from the beginning.
+func (ks *KubernetesSource) Reset() error {
+	ks.index = 0
+	return nil
 }
 
 // InitializeDynamicClient returns a dynamic client

--- a/pkg/migration/kubernetes_test.go
+++ b/pkg/migration/kubernetes_test.go
@@ -114,7 +114,7 @@ func TestNewKubernetesSource(t *testing.T) {
 				},
 			}
 
-			ks, err := NewKubernetesSource(r, dynamicClient, memory.NewMemCacheClient(client.Discovery()))
+			ks, err := NewKubernetesSource(dynamicClient, memory.NewMemCacheClient(client.Discovery()), WithRegistry(r))
 			if diff := cmp.Diff(tc.want.err, err); diff != "" {
 				t.Errorf("\nNext(...): -want, +got:\n%s", diff)
 			}

--- a/pkg/migration/kubernetes_test.go
+++ b/pkg/migration/kubernetes_test.go
@@ -8,7 +8,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	fake2 "k8s.io/client-go/discovery/fake"
+	"k8s.io/client-go/discovery/cached/memory"
 	"k8s.io/client-go/dynamic/fake"
 	fakeclientset "k8s.io/client-go/kubernetes/fake"
 )
@@ -33,6 +33,11 @@ func TestNewKubernetesSource(t *testing.T) {
 						Group:   "ec2.aws.crossplane.io",
 						Version: "v1beta1",
 						Kind:    "VPC",
+					},
+					{
+						Group:   "azure.crossplane.io",
+						Version: "v1beta1",
+						Kind:    "ResourceGroup",
 					},
 				},
 			},
@@ -64,8 +69,11 @@ func TestNewKubernetesSource(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			s := runtime.NewScheme()
 			r := NewRegistry(s)
-			// register a dummy converter so that MRs will be observed
-			r.resourceConverters = map[schema.GroupVersionKind]ResourceConverter{tc.args.gvks[0]: nil}
+			// register a dummy converter for the test GVKs
+			r.resourceConverters = map[schema.GroupVersionKind]ResourceConverter{}
+			for _, gvk := range tc.args.gvks {
+				r.resourceConverters[gvk] = nil
+			}
 			dynamicClient := fake.NewSimpleDynamicClientWithCustomListKinds(s,
 				map[schema.GroupVersionResource]string{
 					{
@@ -89,21 +97,24 @@ func TestNewKubernetesSource(t *testing.T) {
 				{
 					GroupVersion: "ec2.aws.crossplane.io/v1beta1",
 					APIResources: []metav1.APIResource{
-						{Name: "vpcs"},
+						{
+							Name: "vpcs",
+							Kind: "VPC",
+						},
 					},
 				},
 				{
 					GroupVersion: "azure.crossplane.io/v1beta1",
 					APIResources: []metav1.APIResource{
-						{Name: "resourcegroups"},
+						{
+							Name: "resourcegroups",
+							Kind: "ResourceGroup",
+						},
 					},
 				},
 			}
-			fakeDiscovery, ok := client.Discovery().(*fake2.FakeDiscovery)
-			if !ok {
-				t.Fatalf("couldn't convert Discovery() to *FakeDiscovery")
-			}
-			ks, err := NewKubernetesSource(r, dynamicClient, fakeDiscovery, "crossplane.io")
+
+			ks, err := NewKubernetesSource(r, dynamicClient, memory.NewMemCacheClient(client.Discovery()))
 			if diff := cmp.Diff(tc.want.err, err); diff != "" {
 				t.Errorf("\nNext(...): -want, +got:\n%s", diff)
 			}

--- a/pkg/migration/package_lock_steps.go
+++ b/pkg/migration/package_lock_steps.go
@@ -1,0 +1,70 @@
+// Copyright 2023 Upbound Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migration
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func (pg *PlanGenerator) convertPackageLock(o UnstructuredWithMetadata) error {
+	lock, err := toPackageLock(o.Object)
+	if err != nil {
+		return err
+	}
+	isConverted := false
+	for _, lockConv := range pg.registry.packageLockConverters {
+		if lockConv.re == nil || lockConv.converter == nil || !lockConv.re.MatchString(lock.GetName()) {
+			continue
+		}
+		if err := lockConv.converter.PackageLockV1Beta1(lock); err != nil {
+			return errors.Wrapf(err, "failed to call converter on package lock: %s", lock.GetName())
+		}
+		// TODO: if a lock converter does not convert the given lock,
+		// we will have a false positive. Better to compute and check
+		// a diff here.
+		isConverted = true
+	}
+	if !isConverted {
+		return nil
+	}
+	target := &UnstructuredWithMetadata{
+		Object:   ToSanitizedUnstructured(lock),
+		Metadata: o.Metadata,
+	}
+	if err := pg.stepEditPackageLock(o, target); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (pg *PlanGenerator) stepEditPackageLock(source UnstructuredWithMetadata, t *UnstructuredWithMetadata) error {
+	// add step for editing the package lock
+	s := pg.stepConfiguration(stepEditPackageLock)
+	t.Metadata.Path = fmt.Sprintf("%s/%s.yaml", s.Name, getVersionedName(t.Object))
+	s.Patch.Files = append(s.Patch.Files, t.Metadata.Path)
+	patchMap, err := computeJSONMergePathDoc(source.Object, t.Object)
+	if err != nil {
+		return err
+	}
+	return errors.Wrap(pg.target.Put(UnstructuredWithMetadata{
+		Object: unstructured.Unstructured{
+			Object: addNameGVK(t.Object, patchMap),
+		},
+		Metadata: t.Metadata,
+	}), errEditConfigurationPackageFmt)
+}

--- a/pkg/migration/plan_generator.go
+++ b/pkg/migration/plan_generator.go
@@ -48,6 +48,7 @@ const (
 	errConfigurationMetadataMigrateFmt = "failed to migrate the configuration metadata: %s"
 	errConfigurationPackageMigrateFmt  = "failed to migrate the configuration package: %s"
 	errProviderMigrateFmt              = "failed to migrate the Provider package: %s"
+	errLockMigrateFmt                  = "failed to migrate the package lock: %s"
 	errComposedTemplateBase            = "failed to migrate the base of a composed template"
 	errComposedTemplateMigrate         = "failed to migrate the composed templates of the composition"
 	errResourceOutput                  = "failed to output migrated resource"
@@ -256,6 +257,9 @@ func (pg *PlanGenerator) convert() error { //nolint: gocyclo
 				}
 			}
 		case xppkgv1beta1.LockGroupVersionKind:
+			if err := pg.convertPackageLock(o); err != nil {
+				return errors.Wrapf(err, errLockMigrateFmt, o.Object.GetName())
+			}
 		default:
 			if o.Metadata.Category == CategoryComposite {
 				if err := pg.stepPauseComposite(&o); err != nil {

--- a/pkg/migration/plan_generator.go
+++ b/pkg/migration/plan_generator.go
@@ -224,14 +224,8 @@ func (pg *PlanGenerator) convert() error { //nolint: gocyclo
 				return errors.Wrapf(err, errConfigurationPackageMigrateFmt, o.Object.GetName())
 			}
 		case xpmetav1.ConfigurationGroupVersionKind, xpmetav1alpha1.ConfigurationGroupVersionKind:
-			target, converted, err := pg.convertConfigurationMetadata(o)
-			if err != nil {
+			if err := pg.convertConfigurationMetadata(o); err != nil {
 				return errors.Wrapf(err, errConfigurationMetadataMigrateFmt, o.Object.GetName())
-			}
-			if converted {
-				if err := pg.stepEditConfigurationMetadata(o, target); err != nil {
-					return err
-				}
 			}
 		case xpv1.CompositionGroupVersionKind:
 			target, converted, err := pg.convertComposition(o)

--- a/pkg/migration/plan_generator_test.go
+++ b/pkg/migration/plan_generator_test.go
@@ -21,19 +21,15 @@ import (
 	"regexp"
 	"testing"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	xppkgv1 "github.com/crossplane/crossplane/apis/pkg/v1"
-
-	"github.com/google/go-cmp/cmp/cmpopts"
-
-	xpmetav1alpha1 "github.com/crossplane/crossplane/apis/pkg/meta/v1alpha1"
-
 	xpresource "github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
 	xpmetav1 "github.com/crossplane/crossplane/apis/pkg/meta/v1"
+	xpmetav1alpha1 "github.com/crossplane/crossplane/apis/pkg/meta/v1alpha1"
+	xppkgv1 "github.com/crossplane/crossplane/apis/pkg/v1"
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -54,6 +50,7 @@ func TestGeneratePlan(t *testing.T) {
 		migrationPlanPath string
 		// names of resource files to be loaded
 		migratedResourceNames []string
+		preProcessResults     map[Category][]string
 	}
 	tests := map[string]struct {
 		fields fields
@@ -63,21 +60,36 @@ func TestGeneratePlan(t *testing.T) {
 			fields: fields{
 				source:   newTestSource(map[string]Metadata{}),
 				target:   newTestTarget(),
-				registry: getRegistryWithConverters(nil, nil, nil, nil, nil),
+				registry: getRegistry(),
 			},
 			want: want{},
+		},
+		"PreProcess": {
+			fields: fields{
+				source: newTestSource(map[string]Metadata{
+					"testdata/plan/composition.yaml": {Category: CategoryComposition},
+				}),
+				target:   newTestTarget(),
+				registry: getRegistry(withPreProcessor(CategoryComposition, &preProcessor{})),
+			},
+			want: want{
+				preProcessResults: map[Category][]string{
+					CategoryComposition: {"example.compositions.apiextensions.crossplane.io_v1"},
+				},
+			},
 		},
 		"PlanWithManagedResourceAndClaim": {
 			fields: fields{
 				source: newTestSource(map[string]Metadata{
-					"testdata/plan/sourcevpc.yaml":   {},
+					"testdata/plan/sourcevpc.yaml":   {Category: CategoryManaged},
 					"testdata/plan/claim.yaml":       {Category: CategoryClaim},
 					"testdata/plan/composition.yaml": {},
 					"testdata/plan/xrd.yaml":         {},
 					"testdata/plan/xr.yaml":          {Category: CategoryComposite}}),
 				target: newTestTarget(),
-				registry: getRegistryWithConverters(map[schema.GroupVersionKind]delegatingConverter{
-					fake.MigrationSourceGVK: {
+				registry: getRegistry(
+					withPreProcessor(CategoryManaged, &preProcessor{}),
+					withDelegatingConverter(fake.MigrationSourceGVK, delegatingConverter{
 						rFn: func(mg xpresource.Managed) ([]xpresource.Managed, error) {
 							s := mg.(*fake.MigrationSourceObject)
 							t := &fake.MigrationTargetObject{}
@@ -107,13 +119,11 @@ func TestGeneratePlan(t *testing.T) {
 							}
 							return nil
 						},
-					},
-				}, []patchSetConverter{
-					{
+					}),
+					withPatchSetConverter(patchSetConverter{
 						re:        AllCompositions,
 						converter: &testConverter{},
-					},
-				}, nil, nil, nil),
+					})),
 			},
 			want: want{
 				migrationPlanPath: "testdata/plan/generated/migration_plan.yaml",
@@ -128,19 +138,21 @@ func TestGeneratePlan(t *testing.T) {
 					"start-composites/my-resource-dwjgh.xmyresources.test.com.yaml",
 					"create-new-managed/sample-vpc.vpcs.faketargetapi.yaml",
 				},
+				preProcessResults: map[Category][]string{
+					CategoryManaged: {"sample-vpc.vpcs.fakesourceapi_v1alpha1"},
+				},
 			},
 		},
-		"PlanWithConfigurationV1": {
+		"PlanWithConfigurationMetaV1": {
 			fields: fields{
 				source: newTestSource(map[string]Metadata{
 					"testdata/plan/configurationv1.yaml": {}}),
 				target: newTestTarget(),
-				registry: getRegistryWithConverters(nil, nil, []configurationMetadataConverter{
-					{
+				registry: getRegistry(
+					withConfigurationMetadataConverter(configurationMetadataConverter{
 						re:        AllConfigurations,
 						converter: &configurationMetaTestConverter{},
-					},
-				}, nil, nil),
+					})),
 			},
 			want: want{
 				migrationPlanPath: "testdata/plan/generated/configurationv1_migration_plan.yaml",
@@ -149,17 +161,16 @@ func TestGeneratePlan(t *testing.T) {
 				},
 			},
 		},
-		"PlanWithConfigurationV1Alpha1": {
+		"PlanWithConfigurationMetaV1Alpha1": {
 			fields: fields{
 				source: newTestSource(map[string]Metadata{
 					"testdata/plan/configurationv1alpha1.yaml": {}}),
 				target: newTestTarget(),
-				registry: getRegistryWithConverters(nil, nil, []configurationMetadataConverter{
-					{
+				registry: getRegistry(
+					withConfigurationMetadataConverter(configurationMetadataConverter{
 						re:        AllConfigurations,
 						converter: &configurationMetaTestConverter{},
-					},
-				}, nil, nil),
+					})),
 			},
 			want: want{
 				migrationPlanPath: "testdata/plan/generated/configurationv1alpha1_migration_plan.yaml",
@@ -173,17 +184,15 @@ func TestGeneratePlan(t *testing.T) {
 				source: newTestSource(map[string]Metadata{
 					"testdata/plan/providerv1.yaml": {}}),
 				target: newTestTarget(),
-				registry: getRegistryWithConverters(nil, nil, nil, nil,
-					[]providerPackageConverter{
-						{
-							re:        regexp.MustCompile(`xpkg.upbound.io/upbound/provider-aws:.+`),
-							converter: &monolithProviderToFamilyConfigConverter{},
-						},
-						{
-							re:        regexp.MustCompile(`xpkg.upbound.io/upbound/provider-aws:.+`),
-							converter: &monolithicProviderToSSOPConverter{},
-						},
+				registry: getRegistry(
+					withProviderPackageConverter(providerPackageConverter{
+						re:        regexp.MustCompile(`xpkg.upbound.io/upbound/provider-aws:.+`),
+						converter: &monolithProviderToFamilyConfigConverter{},
 					}),
+					withProviderPackageConverter(providerPackageConverter{
+						re:        regexp.MustCompile(`xpkg.upbound.io/upbound/provider-aws:.+`),
+						converter: &monolithicProviderToSSOPConverter{},
+					})),
 			},
 			want: want{
 				migrationPlanPath: "testdata/plan/generated/providerv1_migration_plan.yaml",
@@ -205,28 +214,23 @@ func TestGeneratePlan(t *testing.T) {
 					"testdata/plan/configurationpkgv1.yaml": {},
 				}),
 				target: newTestTarget(),
-				registry: getRegistryWithConverters(nil, nil,
-					[]configurationMetadataConverter{
-						{
-							re:        AllConfigurations,
-							converter: &configurationMetaTestConverter{},
-						},
-					}, []configurationPackageConverter{
-						{
-							re:        regexp.MustCompile(`xpkg.upbound.io/upbound/provider-ref-aws:.+`),
-							converter: &configurationPackageTestConverter{},
-						},
-					},
-					[]providerPackageConverter{
-						{
-							re:        regexp.MustCompile(`xpkg.upbound.io/upbound/provider-aws:.+`),
-							converter: &monolithProviderToFamilyConfigConverter{},
-						},
-						{
-							re:        regexp.MustCompile(`xpkg.upbound.io/upbound/provider-aws:.+`),
-							converter: &monolithicProviderToSSOPConverter{},
-						},
+				registry: getRegistry(
+					withConfigurationMetadataConverter(configurationMetadataConverter{
+						re:        AllConfigurations,
+						converter: &configurationMetaTestConverter{},
 					}),
+					withConfigurationPackageConverter(configurationPackageConverter{
+						re:        regexp.MustCompile(`xpkg.upbound.io/upbound/provider-ref-aws:.+`),
+						converter: &configurationPackageTestConverter{},
+					}),
+					withProviderPackageConverter(providerPackageConverter{
+						re:        regexp.MustCompile(`xpkg.upbound.io/upbound/provider-aws:.+`),
+						converter: &monolithProviderToFamilyConfigConverter{},
+					}),
+					withProviderPackageConverter(providerPackageConverter{
+						re:        regexp.MustCompile(`xpkg.upbound.io/upbound/provider-aws:.+`),
+						converter: &monolithicProviderToSSOPConverter{},
+					})),
 			},
 			want: want{
 				migrationPlanPath: "testdata/plan/generated/configurationv1_providerv1_migration_plan.yaml",
@@ -255,6 +259,17 @@ func TestGeneratePlan(t *testing.T) {
 			}
 			if err != nil {
 				return
+			}
+			// compare preprocessor results
+			for c, results := range tt.want.preProcessResults {
+				pps := tt.fields.registry.unstructuredPreProcessors[c]
+				if len(pps) != 1 {
+					t.Fatalf("One pre-processor must have been registered for category: %s", c)
+				}
+				pp := pps[0].(*preProcessor)
+				if diff := cmp.Diff(results, pp.results); diff != "" {
+					t.Errorf("GeneratePlan(): -wantPreProcessorResults, +gotPreProcessorResults: %s", diff)
+				}
 			}
 			// compare generated plan with the expected plan
 			p, err := loadPlan(tt.want.migrationPlanPath)
@@ -331,6 +346,11 @@ func (f *testSource) Next() (UnstructuredWithMetadata, error) {
 	return um, nil
 }
 
+func (f *testSource) Reset() error {
+	f.index = 0
+	return nil
+}
+
 type testTarget struct {
 	targetManifests map[string]UnstructuredWithMetadata
 }
@@ -381,26 +401,51 @@ func ptrFromString(s string) *string {
 	return &s
 }
 
-func getRegistryWithConverters(converters map[schema.GroupVersionKind]delegatingConverter, psConverters []patchSetConverter, confMetaConverters []configurationMetadataConverter, confPackageConverters []configurationPackageConverter,
-	providerPkgConverters []providerPackageConverter) *Registry {
+type registryOption func(*Registry)
+
+func withDelegatingConverter(gvk schema.GroupVersionKind, d delegatingConverter) registryOption {
+	return func(r *Registry) {
+		r.RegisterAPIConversionFunctions(gvk, d.rFn, d.cmpFn, nil)
+	}
+}
+
+func withPatchSetConverter(c patchSetConverter) registryOption {
+	return func(r *Registry) {
+		r.RegisterPatchSetConverter(c.re, c.converter)
+	}
+}
+
+func withConfigurationMetadataConverter(c configurationMetadataConverter) registryOption {
+	return func(r *Registry) {
+		r.RegisterConfigurationMetadataConverter(c.re, c.converter)
+	}
+}
+
+func withConfigurationPackageConverter(c configurationPackageConverter) registryOption {
+	return func(r *Registry) {
+		r.RegisterConfigurationPackageConverter(c.re, c.converter)
+	}
+}
+
+func withProviderPackageConverter(c providerPackageConverter) registryOption {
+	return func(r *Registry) {
+		r.RegisterProviderPackageConverter(c.re, c.converter)
+	}
+}
+
+func withPreProcessor(c Category, pp UnstructuredPreProcessor) registryOption {
+	return func(r *Registry) {
+		r.RegisterPreProcessor(c, pp)
+	}
+}
+
+func getRegistry(opts ...registryOption) *Registry {
 	scheme := runtime.NewScheme()
 	scheme.AddKnownTypeWithName(fake.MigrationSourceGVK, &fake.MigrationSourceObject{})
 	scheme.AddKnownTypeWithName(fake.MigrationTargetGVK, &fake.MigrationTargetObject{})
 	r := NewRegistry(scheme)
-	for _, c := range psConverters {
-		r.RegisterPatchSetConverter(c.re, c.converter)
-	}
-	for _, c := range confMetaConverters {
-		r.RegisterConfigurationConverter(c.re, c.converter)
-	}
-	for _, c := range confPackageConverters {
-		r.RegisterConfigurationPackageConverter(c.re, c.converter)
-	}
-	for _, c := range providerPkgConverters {
-		r.RegisterProviderPackageConverter(c.re, c.converter)
-	}
-	for gvk, d := range converters {
-		r.RegisterAPIConversionFunctions(gvk, d.rFn, d.cmpFn, nil)
+	for _, o := range opts {
+		o(r)
 	}
 	return r
 }
@@ -499,4 +544,13 @@ func (c *monolithicProviderToSSOPConverter) ProviderPackageV1(_ xppkgv1.Provider
 			},
 		},
 	}, nil
+}
+
+type preProcessor struct {
+	results []string
+}
+
+func (pp *preProcessor) PreProcess(u UnstructuredWithMetadata) error {
+	pp.results = append(pp.results, getVersionedName(u.Object))
+	return nil
 }

--- a/pkg/migration/plan_steps.go
+++ b/pkg/migration/plan_steps.go
@@ -19,14 +19,11 @@ import (
 	"sort"
 	"strings"
 
-	"k8s.io/apimachinery/pkg/util/rand"
-
-	"k8s.io/apimachinery/pkg/util/jsonmergepatch"
-
 	"github.com/pkg/errors"
-
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/json"
+	"k8s.io/apimachinery/pkg/util/jsonmergepatch"
+	"k8s.io/apimachinery/pkg/util/rand"
 )
 
 type step int

--- a/pkg/migration/registry.go
+++ b/pkg/migration/registry.go
@@ -446,3 +446,14 @@ func (r *Registry) RegisterConversionFunctions(gvk schema.GroupVersionKind, rFn 
 func (r *Registry) RegisterPreProcessor(category Category, pp UnstructuredPreProcessor) {
 	r.unstructuredPreProcessors[category] = append(r.unstructuredPreProcessors[category], pp)
 }
+
+// PreProcessor is a function type to convert pre-processor functions to
+// UnstructuredPreProcessor.
+type PreProcessor func(u UnstructuredWithMetadata) error
+
+func (pp PreProcessor) PreProcess(u UnstructuredWithMetadata) error {
+	if pp == nil {
+		return nil
+	}
+	return pp(u)
+}

--- a/pkg/migration/testdata/plan/generated/configurationv1_providerv1_migration_plan.yaml
+++ b/pkg/migration/testdata/plan/generated/configurationv1_providerv1_migration_plan.yaml
@@ -20,6 +20,13 @@ spec:
       name: disable-dependency-resolution
       type: Patch
 
+    - patch:
+        type: merge
+        files:
+          - edit-package-lock/lock.locks.pkg.crossplane.io_v1beta1.yaml
+      name: edit-package-lock
+      type: Patch
+
     - delete:
         options:
           finalizerPolicy: Remove

--- a/pkg/migration/testdata/plan/generated/edit-package-lock/lock.locks.pkg.crossplane.io_v1beta1.yaml
+++ b/pkg/migration/testdata/plan/generated/edit-package-lock/lock.locks.pkg.crossplane.io_v1beta1.yaml
@@ -1,0 +1,14 @@
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Lock
+metadata:
+  name: lock
+packages:
+  - name: provider-aws
+    type: Provider
+    source: xpkg.upbound.io/upbound/provider-aws
+    version: v0.36.0
+  - name: test-provider
+    type: Provider
+    source: xpkg.upbound.io/upbound/test-provider
+    version: vX.Y.Z
+

--- a/pkg/migration/testdata/plan/lockv1beta1.yaml
+++ b/pkg/migration/testdata/plan/lockv1beta1.yaml
@@ -1,0 +1,13 @@
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Lock
+metadata:
+  creationTimestamp: "2023-05-15T12:37:16Z"
+  generation: 9
+  name: lock
+  resourceVersion: "10366"
+  uid: b1aabaaa-56bb-4356-ae45-1e3131cb9743
+packages:
+  - name: provider-aws
+    type: Provider
+    source: xpkg.upbound.io/upbound/provider-aws
+    version: v0.36.0

--- a/pkg/migration/types.go
+++ b/pkg/migration/types.go
@@ -30,6 +30,7 @@ const (
 
 // Resource categories
 const (
+	categoryUnknown Category = ""
 	// CategoryClaim category for composite claim resources
 	CategoryClaim Category = "Claim"
 	// CategoryComposite category for composite resources

--- a/pkg/migration/types.go
+++ b/pkg/migration/types.go
@@ -32,13 +32,13 @@ const (
 const (
 	categoryUnknown Category = ""
 	// CategoryClaim category for composite claim resources
-	CategoryClaim Category = "Claim"
+	CategoryClaim Category = "claim"
 	// CategoryComposite category for composite resources
-	CategoryComposite Category = "Composite"
+	CategoryComposite Category = "composite"
 	// CategoryComposition category for compositions
-	CategoryComposition Category = "Composition"
+	CategoryComposition Category = "composition"
 	// CategoryManaged category for managed resources
-	CategoryManaged Category = "Managed"
+	CategoryManaged Category = "managed"
 )
 
 // Plan represents a migration plan for migrating managed resources,
@@ -170,6 +170,11 @@ type Resource struct {
 
 // Category specifies if a resource is a Claim, Composite or a Managed resource
 type Category string
+
+// String returns a string representing the receiver Category.
+func (c Category) String() string {
+	return string(c)
+}
 
 // Metadata holds metadata for an object read from a Source
 type Metadata struct {


### PR DESCRIPTION
<!--
Thank you for helping to improve Upjet!

Please read through https://git.io/fj2m9 if this is your first time opening a
Upjet pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Upjet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This PR adds support for category-based manifest pre-processors which can optionally be registered with a migration registry and are called before any converters are called. They cannot mutate resources (this is the job of converters) and they can only be used to extract information from the manifests belonging to a specific category such as the managed resources or compositions. Pre-processors can be used to initialize converters with information extracted from the manifests emitted by a source.

Following changes are also introduced in this PR:
- Support for `Lock.pkg` converters
- Use [`meta.RESTMapper`](https://pkg.go.dev/k8s.io/apimachinery/pkg/api/meta#RESTMapper) for converting from GVKs to GVRs in `migration.KubernetesSource` and remove all references of `meta.UnsafeGuessKindToResource`.
- Fix a panic when no converters act on an observed `Configuration.meta`

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
