### PR TITLE
Remove the trailing document separator (---) from examples generated

### DIFF
--- a/pkg/examples/example.go
+++ b/pkg/examples/example.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -105,8 +104,11 @@ func (eg *Generator) StoreExamples() error { // nolint:gocyclo
 				}
 			}
 		}
+
+		newBuff := bytes.TrimSuffix(buff.Bytes(), []byte("\n---\n\n"))
+
 		// no sensitive info in the example manifest
-		if err := ioutil.WriteFile(pm.ManifestPath, buff.Bytes(), 0600); err != nil {
+		if err := os.WriteFile(pm.ManifestPath, newBuff, 0600); err != nil {
 			return errors.Wrapf(err, "cannot write example manifest file %s for resource %s", pm.ManifestPath, rn)
 		}
 	}


### PR DESCRIPTION
### Description of your changes

This PR removes the document separator at the end of examples generated in upjet-based providers.

Fixes: https://github.com/upbound/upjet/issues/196

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Manually tested in `turkenf/upjet` and `turkenf/provider-azuread`.

[contribution process]: https://git.io/fj2m9
