### PR TITLE
Fast Follow: Converting upjet to component to include CI visibility

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,5 +1,5 @@
 apiVersion: backstage.io/v1alpha1
-kind: System
+kind: Component
 metadata:
   name: upjet
   description: "A code generation framework and runtime for Crossplane providers"
@@ -9,4 +9,6 @@ metadata:
   annotations:
     github.com/project-slug: upbound/upjet
 spec:
+  type: library
+  lifecycle: production
   owner: team:extensions


### PR DESCRIPTION
<!--
Thank you for helping to improve Upjet!

Please read through https://git.io/fj2m9 if this is your first time opening a
Upjet pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Fast follow on https://github.com/upbound/upjet/pull/228, converting Backstage abstraction level to `component` to allow for CI visibility.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

N/A

[contribution process]: https://git.io/fj2m9
