### PR TITLE
Requeue the reconcile request on async update error

### DIFF
--- a/pkg/controller/api_test.go
+++ b/pkg/controller/api_test.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"testing"
 
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -66,6 +68,11 @@ func TestAPICallbacksCreate(t *testing.T) {
 					Scheme: xpfake.SchemeWith(&fake.Terraformed{}),
 				},
 				err: tjerrors.NewApplyFailed(nil),
+			},
+			want: want{
+				// because the queue is not set, we expect a successful
+				// status update but a failed attempt to requeue the request.
+				err: errors.Errorf(errReconcileRequestFmt, schema.GroupVersionKind{}, "name", "create"),
 			},
 		},
 		"CreateOperationSucceeded": {
@@ -148,6 +155,11 @@ func TestAPICallbacksUpdate(t *testing.T) {
 					Scheme: xpfake.SchemeWith(&fake.Terraformed{}),
 				},
 				err: tjerrors.NewApplyFailed(nil),
+			},
+			want: want{
+				// because the queue is not set, we expect a successful
+				// status update but a failed attempt to requeue the request.
+				err: errors.Errorf(errReconcileRequestFmt, schema.GroupVersionKind{}, "name", "update"),
 			},
 		},
 		"ApplyOperationSucceeded": {

--- a/pkg/controller/api_test.go
+++ b/pkg/controller/api_test.go
@@ -34,7 +34,7 @@ import (
 	tjerrors "github.com/upbound/upjet/pkg/terraform/errors"
 )
 
-func TestAPICallbacks_Apply(t *testing.T) {
+func TestAPICallbacksCreate(t *testing.T) {
 	type args struct {
 		mgr ctrl.Manager
 		mg  xpresource.ManagedKind
@@ -48,7 +48,7 @@ func TestAPICallbacks_Apply(t *testing.T) {
 		args
 		want
 	}{
-		"ApplyOperationFailed": {
+		"CreateOperationFailed": {
 			reason: "It should update the condition with error if async apply failed",
 			args: args{
 				mg: xpresource.ManagedKind(xpfake.GVK(&fake.Terraformed{})),
@@ -58,7 +58,7 @@ func TestAPICallbacks_Apply(t *testing.T) {
 						MockStatusUpdate: func(ctx context.Context, obj client.Object, opts ...client.SubResourceUpdateOption) error {
 							got := obj.(resource.Terraformed).GetCondition(resource.TypeLastAsyncOperation)
 							if diff := cmp.Diff(resource.LastAsyncOperationCondition(tjerrors.NewApplyFailed(nil)), got); diff != "" {
-								t.Errorf("\nApply(...): -want error, +got error:\n%s", diff)
+								t.Errorf("\nCreate(...): -want error, +got error:\n%s", diff)
 							}
 							return nil
 						},
@@ -68,7 +68,7 @@ func TestAPICallbacks_Apply(t *testing.T) {
 				err: tjerrors.NewApplyFailed(nil),
 			},
 		},
-		"ApplyOperationSucceeded": {
+		"CreateOperationSucceeded": {
 			reason: "It should update the condition with success if the apply operation does not report error",
 			args: args{
 				mg: xpresource.ManagedKind(xpfake.GVK(&fake.Terraformed{})),
@@ -78,7 +78,7 @@ func TestAPICallbacks_Apply(t *testing.T) {
 						MockStatusUpdate: func(ctx context.Context, obj client.Object, opts ...client.SubResourceUpdateOption) error {
 							got := obj.(resource.Terraformed).GetCondition(resource.TypeLastAsyncOperation)
 							if diff := cmp.Diff(resource.LastAsyncOperationCondition(nil), got); diff != "" {
-								t.Errorf("\nApply(...): -want error, +got error:\n%s", diff)
+								t.Errorf("\nCreate(...): -want error, +got error:\n%s", diff)
 							}
 							return nil
 						},
@@ -101,16 +101,98 @@ func TestAPICallbacks_Apply(t *testing.T) {
 				},
 			},
 			want: want{
-				err: errors.Wrap(errBoom, errGet),
+				err: errors.Wrapf(errBoom, errGetFmt, "", ", Kind=/name", "create"),
 			},
 		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			e := NewAPICallbacks(tc.args.mgr, tc.args.mg)
-			err := e.Apply("name")(tc.args.err, context.TODO())
+			err := e.Create("name")(tc.args.err, context.TODO())
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
-				t.Errorf("\n%s\nApply(...): -want error, +got error:\n%s", tc.reason, diff)
+				t.Errorf("\n%s\nCreate(...): -want error, +got error:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestAPICallbacksUpdate(t *testing.T) {
+	type args struct {
+		mgr ctrl.Manager
+		mg  xpresource.ManagedKind
+		err error
+	}
+	type want struct {
+		err error
+	}
+	cases := map[string]struct {
+		reason string
+		args
+		want
+	}{
+		"UpdateOperationFailed": {
+			reason: "It should update the condition with error if async apply failed",
+			args: args{
+				mg: xpresource.ManagedKind(xpfake.GVK(&fake.Terraformed{})),
+				mgr: &xpfake.Manager{
+					Client: &test.MockClient{
+						MockGet: test.NewMockGetFn(nil),
+						MockStatusUpdate: func(ctx context.Context, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+							got := obj.(resource.Terraformed).GetCondition(resource.TypeLastAsyncOperation)
+							if diff := cmp.Diff(resource.LastAsyncOperationCondition(tjerrors.NewApplyFailed(nil)), got); diff != "" {
+								t.Errorf("\nUpdate(...): -want error, +got error:\n%s", diff)
+							}
+							return nil
+						},
+					},
+					Scheme: xpfake.SchemeWith(&fake.Terraformed{}),
+				},
+				err: tjerrors.NewApplyFailed(nil),
+			},
+		},
+		"ApplyOperationSucceeded": {
+			reason: "It should update the condition with success if the apply operation does not report error",
+			args: args{
+				mg: xpresource.ManagedKind(xpfake.GVK(&fake.Terraformed{})),
+				mgr: &xpfake.Manager{
+					Client: &test.MockClient{
+						MockGet: test.NewMockGetFn(nil),
+						MockStatusUpdate: func(ctx context.Context, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+							got := obj.(resource.Terraformed).GetCondition(resource.TypeLastAsyncOperation)
+							if diff := cmp.Diff(resource.LastAsyncOperationCondition(nil), got); diff != "" {
+								t.Errorf("\nUpdate(...): -want error, +got error:\n%s", diff)
+							}
+							return nil
+						},
+					},
+					Scheme: xpfake.SchemeWith(&fake.Terraformed{}),
+				},
+			},
+		},
+		"CannotGet": {
+			reason: "It should return error if it cannot get the resource to update",
+			args: args{
+				mg: xpresource.ManagedKind(xpfake.GVK(&fake.Terraformed{})),
+				mgr: &xpfake.Manager{
+					Client: &test.MockClient{
+						MockGet: func(_ context.Context, _ client.ObjectKey, _ client.Object) error {
+							return errBoom
+						},
+					},
+					Scheme: xpfake.SchemeWith(&fake.Terraformed{}),
+				},
+			},
+			want: want{
+				err: errors.Wrapf(errBoom, errGetFmt, "", ", Kind=/name", "update"),
+			},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			e := NewAPICallbacks(tc.args.mgr, tc.args.mg)
+			err := e.Update("name")(tc.args.err, context.TODO())
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nUpdate(...): -want error, +got error:\n%s", tc.reason, diff)
 			}
 		})
 	}
@@ -183,7 +265,7 @@ func TestAPICallbacks_Destroy(t *testing.T) {
 				},
 			},
 			want: want{
-				err: errors.Wrap(errBoom, errGet),
+				err: errors.Wrapf(errBoom, errGetFmt, "", ", Kind=/name", "destroy"),
 			},
 		},
 	}

--- a/pkg/controller/api_test.go
+++ b/pkg/controller/api_test.go
@@ -20,8 +20,6 @@ import (
 	"context"
 	"testing"
 
-	"k8s.io/apimachinery/pkg/runtime/schema"
-
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -68,11 +66,6 @@ func TestAPICallbacksCreate(t *testing.T) {
 					Scheme: xpfake.SchemeWith(&fake.Terraformed{}),
 				},
 				err: tjerrors.NewApplyFailed(nil),
-			},
-			want: want{
-				// because the queue is not set, we expect a successful
-				// status update but a failed attempt to requeue the request.
-				err: errors.Errorf(errReconcileRequestFmt, schema.GroupVersionKind{}, "name", "create"),
 			},
 		},
 		"CreateOperationSucceeded": {
@@ -155,11 +148,6 @@ func TestAPICallbacksUpdate(t *testing.T) {
 					Scheme: xpfake.SchemeWith(&fake.Terraformed{}),
 				},
 				err: tjerrors.NewApplyFailed(nil),
-			},
-			want: want{
-				// because the queue is not set, we expect a successful
-				// status update but a failed attempt to requeue the request.
-				err: errors.Errorf(errReconcileRequestFmt, schema.GroupVersionKind{}, "name", "update"),
 			},
 		},
 		"ApplyOperationSucceeded": {

--- a/pkg/controller/external.go
+++ b/pkg/controller/external.go
@@ -34,7 +34,6 @@ const (
 	errStartAsyncDestroy = "cannot start async destroy"
 	errApply             = "cannot apply"
 	errDestroy           = "cannot destroy"
-	errStatusUpdate      = "cannot update status of custom resource"
 	errScheduleProvider  = "cannot schedule native Terraform provider process"
 	errUpdateAnnotations = "cannot update managed resource annotations"
 )
@@ -311,7 +310,7 @@ func (e *external) Create(ctx context.Context, mg xpresource.Managed) (managed.E
 	}
 	defer e.stopProvider()
 	if e.config.UseAsync {
-		return managed.ExternalCreation{}, errors.Wrap(e.workspace.ApplyAsync(e.callback.Apply(mg.GetName())), errStartAsyncApply)
+		return managed.ExternalCreation{}, errors.Wrap(e.workspace.ApplyAsync(e.callback.Create(mg.GetName())), errStartAsyncApply)
 	}
 	tr, ok := mg.(resource.Terraformed)
 	if !ok {
@@ -342,7 +341,7 @@ func (e *external) Update(ctx context.Context, mg xpresource.Managed) (managed.E
 	}
 	defer e.stopProvider()
 	if e.config.UseAsync {
-		return managed.ExternalUpdate{}, errors.Wrap(e.workspace.ApplyAsync(e.callback.Apply(mg.GetName())), errStartAsyncApply)
+		return managed.ExternalUpdate{}, errors.Wrap(e.workspace.ApplyAsync(e.callback.Update(mg.GetName())), errStartAsyncApply)
 	}
 	tr, ok := mg.(resource.Terraformed)
 	if !ok {

--- a/pkg/controller/external_test.go
+++ b/pkg/controller/external_test.go
@@ -1,6 +1,16 @@
-/*
-Copyright 2021 Upbound Inc.
-*/
+// Copyright 2023 Upbound Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package controller
 
@@ -97,12 +107,17 @@ func (s StoreFns) Workspace(ctx context.Context, c resource.SecretClient, tr res
 }
 
 type CallbackFns struct {
-	ApplyFn   func(string) terraform.CallbackFn
+	CreateFn  func(string) terraform.CallbackFn
+	UpdateFn  func(string) terraform.CallbackFn
 	DestroyFn func(string) terraform.CallbackFn
 }
 
-func (c CallbackFns) Apply(name string) terraform.CallbackFn {
-	return c.ApplyFn(name)
+func (c CallbackFns) Create(name string) terraform.CallbackFn {
+	return c.CreateFn(name)
+}
+
+func (c CallbackFns) Update(name string) terraform.CallbackFn {
+	return c.UpdateFn(name)
 }
 
 func (c CallbackFns) Destroy(name string) terraform.CallbackFn {
@@ -639,7 +654,7 @@ func TestCreate(t *testing.T) {
 					UseAsync: true,
 				},
 				c: CallbackFns{
-					ApplyFn: func(s string) terraform.CallbackFn {
+					CreateFn: func(s string) terraform.CallbackFn {
 						return nil
 					},
 				},
@@ -705,14 +720,14 @@ func TestUpdate(t *testing.T) {
 				err: errors.New(errUnexpectedObject),
 			},
 		},
-		"AsyncFailed": {
+		"AsyncUpdateFailed": {
 			reason: "It should return error if it cannot trigger the async apply",
 			args: args{
 				cfg: &config.Resource{
 					UseAsync: true,
 				},
 				c: CallbackFns{
-					ApplyFn: func(s string) terraform.CallbackFn {
+					UpdateFn: func(s string) terraform.CallbackFn {
 						return nil
 					},
 				},
@@ -727,7 +742,7 @@ func TestUpdate(t *testing.T) {
 				err: errors.Wrap(errBoom, errStartAsyncApply),
 			},
 		},
-		"SyncApplyFailed": {
+		"SyncUpdateFailed": {
 			reason: "It should return error if it cannot apply in sync mode",
 			args: args{
 				cfg: &config.Resource{},

--- a/pkg/controller/handler/eventhandler.go
+++ b/pkg/controller/handler/eventhandler.go
@@ -1,0 +1,99 @@
+// Copyright 2023 Upbound Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handler
+
+import (
+	"context"
+	"sync"
+
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// EventHandler handles Kubernetes events by queueing reconcile requests for
+// objects and allows upjet components to queue reconcile requests.
+type EventHandler struct {
+	innerHandler handler.EventHandler
+	queue        workqueue.RateLimitingInterface
+	rateLimiter  workqueue.RateLimiter
+	mu           *sync.Mutex
+}
+
+// NewEventHandler initializes a new EventHandler instance.
+func NewEventHandler() *EventHandler {
+	return &EventHandler{
+		innerHandler: &handler.EnqueueRequestForObject{},
+		mu:           &sync.Mutex{},
+		rateLimiter:  workqueue.DefaultControllerRateLimiter(),
+	}
+}
+
+// RequestReconcile requeues a reconciliation request for the specified name.
+// Returns true if the reconcile request was successfully queued.
+func (e *EventHandler) RequestReconcile(name string) bool {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.queue == nil {
+		return false
+	}
+	item := reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name: name,
+		},
+	}
+	e.queue.AddAfter(item, e.rateLimiter.When(item))
+	return true
+}
+
+// Forget indicates that the reconcile retries is finished for
+// the specified name.
+func (e *EventHandler) Forget(name string) {
+	e.rateLimiter.Forget(reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name: name,
+		},
+	})
+}
+
+func (e *EventHandler) setQueue(limitingInterface workqueue.RateLimitingInterface) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.queue == nil {
+		e.queue = limitingInterface
+	}
+}
+
+func (e *EventHandler) Create(ctx context.Context, ev event.CreateEvent, limitingInterface workqueue.RateLimitingInterface) {
+	e.setQueue(limitingInterface)
+	e.innerHandler.Create(ctx, ev, limitingInterface)
+}
+
+func (e *EventHandler) Update(ctx context.Context, ev event.UpdateEvent, limitingInterface workqueue.RateLimitingInterface) {
+	e.setQueue(limitingInterface)
+	e.innerHandler.Update(ctx, ev, limitingInterface)
+}
+
+func (e *EventHandler) Delete(ctx context.Context, ev event.DeleteEvent, limitingInterface workqueue.RateLimitingInterface) {
+	e.setQueue(limitingInterface)
+	e.innerHandler.Delete(ctx, ev, limitingInterface)
+}
+
+func (e *EventHandler) Generic(ctx context.Context, ev event.GenericEvent, limitingInterface workqueue.RateLimitingInterface) {
+	e.setQueue(limitingInterface)
+	e.innerHandler.Generic(ctx, ev, limitingInterface)
+}

--- a/pkg/controller/interfaces.go
+++ b/pkg/controller/interfaces.go
@@ -40,6 +40,7 @@ type Store interface {
 // CallbackProvider provides functions that can be called with the result of
 // async operations.
 type CallbackProvider interface {
-	Apply(name string) terraform.CallbackFn
+	Create(name string) terraform.CallbackFn
+	Update(name string) terraform.CallbackFn
 	Destroy(name string) terraform.CallbackFn
 }

--- a/pkg/controller/options.go
+++ b/pkg/controller/options.go
@@ -7,11 +7,11 @@ package controller
 import (
 	"crypto/tls"
 
+	"github.com/crossplane/crossplane-runtime/pkg/controller"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
-	"github.com/crossplane/crossplane-runtime/pkg/controller"
-
 	"github.com/upbound/upjet/pkg/config"
+	"github.com/upbound/upjet/pkg/controller/handler"
 	"github.com/upbound/upjet/pkg/terraform"
 )
 
@@ -42,7 +42,7 @@ type Options struct {
 
 	// EventHandler to handle the Kubernetes events and
 	// to queue reconcile requests.
-	EventHandler *EventHandler
+	EventHandler *handler.EventHandler
 }
 
 // ESSOptions for External Secret Stores.

--- a/pkg/controller/options.go
+++ b/pkg/controller/options.go
@@ -39,6 +39,10 @@ type Options struct {
 
 	// ESSOptions for External Secret Stores.
 	ESSOptions *ESSOptions
+
+	// EventHandler to handle the Kubernetes events and
+	// to queue reconcile requests.
+	EventHandler *EventHandler
 }
 
 // ESSOptions for External Secret Stores.

--- a/pkg/pipeline/templates/controller.go.tmpl
+++ b/pkg/pipeline/templates/controller.go.tmpl
@@ -35,7 +35,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	if o.SecretStoreConfigGVK != nil {
 		cps = append(cps, connection.NewDetailsManager(mgr.GetClient(), *o.SecretStoreConfigGVK, connection.WithTLSConfig(o.ESSOptions.TLSConfig)))
 	}
-	ac := tjcontroller.NewAPICallbacks(mgr, xpresource.ManagedKind({{ .TypePackageAlias }}{{ .CRD.Kind }}_GroupVersionKind))
+	ac := tjcontroller.NewAPICallbacks(mgr, xpresource.ManagedKind({{ .TypePackageAlias }}{{ .CRD.Kind }}_GroupVersionKind), tjcontroller.WithEventHandler(o.EventHandler))
 	opts := []managed.ReconcilerOption{
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), o.WorkspaceStore, o.SetupFn, o.Provider.Resources["{{ .ResourceType }}"], tjcontroller.WithLogger(o.Logger),
 			{{- if .UseAsync }}
@@ -61,6 +61,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		Named(name).
 		WithOptions(o.ForControllerRuntime()).
 		WithEventFilter(xpresource.DesiredStateChanged()).
-		Watches(&{{ .TypePackageAlias }}{{ .CRD.Kind }}{}, ac.EventHandler).
+		Watches(&{{ .TypePackageAlias }}{{ .CRD.Kind }}{}, o.EventHandler).
 		Complete(ratelimiter.NewReconciler(name, r, o.GlobalRateLimiter))
 }

--- a/pkg/pipeline/templates/controller.go.tmpl
+++ b/pkg/pipeline/templates/controller.go.tmpl
@@ -61,7 +61,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		Named(name).
 		WithOptions(o.ForControllerRuntime()).
 		WithEventFilter(xpresource.DesiredStateChanged()).
-		For(&{{ .TypePackageAlias }}{{ .CRD.Kind }}{}).
 		Watches(&{{ .TypePackageAlias }}{{ .CRD.Kind }}{}, ac.EventHandler).
 		Complete(ratelimiter.NewReconciler(name, r, o.GlobalRateLimiter))
 }

--- a/pkg/pipeline/templates/controller.go.tmpl
+++ b/pkg/pipeline/templates/controller.go.tmpl
@@ -35,12 +35,13 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	if o.SecretStoreConfigGVK != nil {
 		cps = append(cps, connection.NewDetailsManager(mgr.GetClient(), *o.SecretStoreConfigGVK, connection.WithTLSConfig(o.ESSOptions.TLSConfig)))
 	}
+	ac := tjcontroller.NewAPICallbacks(mgr, xpresource.ManagedKind({{ .TypePackageAlias }}{{ .CRD.Kind }}_GroupVersionKind))
 	opts := []managed.ReconcilerOption{
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), o.WorkspaceStore, o.SetupFn, o.Provider.Resources["{{ .ResourceType }}"], tjcontroller.WithLogger(o.Logger),
 			{{- if .UseAsync }}
-			tjcontroller.WithCallbackProvider(tjcontroller.NewAPICallbacks(mgr, xpresource.ManagedKind({{ .TypePackageAlias }}{{ .CRD.Kind }}_GroupVersionKind))),
+			tjcontroller.WithCallbackProvider(ac)),
 			{{- end}}
-		)),
+		),
 		managed.WithLogger(o.Logger.WithValues("controller", name)),
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(o.WorkspaceStore, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
@@ -59,6 +60,8 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
 		WithOptions(o.ForControllerRuntime()).
+		WithEventFilter(xpresource.DesiredStateChanged()).
 		For(&{{ .TypePackageAlias }}{{ .CRD.Kind }}{}).
+		Watches(&{{ .TypePackageAlias }}{{ .CRD.Kind }}{}, ac.EventHandler).
 		Complete(ratelimiter.NewReconciler(name, r, o.GlobalRateLimiter))
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Upjet!

Please read through https://git.io/fj2m9 if this is your first time opening a
Upjet pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Upjet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #176 
Fixes #180

This PR employs [the new `DesiredStatusChanged` predicate](https://github.com/crossplane/crossplane-runtime/pull/372) predicate from the crossplane-runtime as an event filter to prevent too-frequent reconciles on error conditions or on updates to the external create [pending](https://github.com/crossplane/crossplane-runtime/blob/4374a3b5d1ff58214b118a7cea641230bfbc785f/pkg/meta/meta.go#L45)/[failed](https://github.com/crossplane/crossplane-runtime/blob/4374a3b5d1ff58214b118a7cea641230bfbc785f/pkg/meta/meta.go#L59) annotations. It also allows the [async callback functions](https://github.com/upbound/upjet/blob/b70acc1bcb6d42499f0310b391f07694d0a97448/pkg/terraform/workspace.go#L131) to requeue a reconcile request with an exponential back-off, when the async operation fails. 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Tested the PR with https://github.com/upbound/provider-aws/pull/789.
When, for example, the external connector's `Connect` call fails, the requeue request is exponentially backed-off with a cap of 1 min. Here are the sample timestamps from an experiment with a `Connect` call failing:
```
2023-07-26T22:40:35+03:00
2023-07-26T22:40:36+03:00
2023-07-26T22:40:37+03:00
2023-07-26T22:40:41+03:00
2023-07-26T22:40:49+03:00
2023-07-26T22:41:05+03:00
2023-07-26T22:41:37+03:00
2023-07-26T22:42:37+03:00
2023-07-26T22:43:37+03:00
```

To test whether we exponentially back-off when we error in asynchronous callbacks, I provisioned an S3 bucket, put a file into it, and attempted to delete the bucket. Here are the timestamps belonging to the (failing) reconciliation attempts while deleting the `Bucket.s3` MR:
```
2023-07-26T23:03:35+03:00
2023-07-26T23:03:42+03:00
2023-07-26T23:03:48+03:00
2023-07-26T23:03:57+03:00
2023-07-26T23:04:06+03:00
2023-07-26T23:04:27+03:00
2023-07-26T23:05:04+03:00
2023-07-26T23:06:09+03:00
2023-07-26T23:07:14+03:00
2023-07-26T23:08:19+03:00
2023-07-26T23:09:24+03:00
2023-07-26T23:10:29+03:00
2023-07-26T23:11:34+03:00
```
, which again shows the reconcile requests are being exponentially backed-off.

We have also done some performance tests and those results can be found [here](https://github.com/upbound/upjet/pull/231#issuecomment-1652315774).

[contribution process]: https://git.io/fj2m9
