### PR TITLE
Support initProvider 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/upbound/upjet
 go 1.20
 
 require (
+	dario.cat/mergo v1.0.0
 	github.com/antchfx/htmlquery v1.2.4
 	github.com/crossplane/crossplane v1.10.0
 	github.com/crossplane/crossplane-runtime v0.20.0
@@ -37,7 +38,6 @@ require (
 )
 
 require (
-	dario.cat/mergo v1.0.0 // indirect
 	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
 	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 // indirect

--- a/pkg/pipeline/crd.go
+++ b/pkg/pipeline/crd.go
@@ -85,13 +85,14 @@ func (cg *CRDGenerator) Generate(cfg *config.Resource) (string, error) {
 	vars := map[string]any{
 		"Types": typesStr,
 		"CRD": map[string]string{
-			"APIVersion":      cfg.Version,
-			"Group":           cg.Group,
-			"Kind":            cfg.Kind,
-			"ForProviderType": gen.ForProviderType.Obj().Name(),
-			"AtProviderType":  gen.AtProviderType.Obj().Name(),
-			"ValidationRules": gen.ValidationRules,
-			"Path":            cfg.Path,
+			"APIVersion":       cfg.Version,
+			"Group":            cg.Group,
+			"Kind":             cfg.Kind,
+			"ForProviderType":  gen.ForProviderType.Obj().Name(),
+			"InitProviderType": gen.InitProviderType.Obj().Name(),
+			"AtProviderType":   gen.AtProviderType.Obj().Name(),
+			"ValidationRules":  gen.ValidationRules,
+			"Path":             cfg.Path,
 		},
 		"Provider": map[string]string{
 			"ShortName": cg.ProviderShortName,

--- a/pkg/pipeline/templates/crd_types.go.tmpl
+++ b/pkg/pipeline/templates/crd_types.go.tmpl
@@ -17,6 +17,18 @@ import (
 type {{ .CRD.Kind }}Spec struct {
 	{{ .XPCommonAPIsPackageAlias }}ResourceSpec `json:",inline"`
 	ForProvider       {{ .CRD.ForProviderType }} `json:"forProvider"`
+	// THIS IS AN ALPHA FIELD. Do not use it in production. It is not honored
+	// unless the relevant Crossplane feature flag is enabled, and may be
+	// changed or removed without notice.
+	// InitProvider holds the same fields as ForProvider, with the exception
+	// of Identifier and other resource reference fields. The fields that are
+	// in InitProvider are merged into ForProvider when the resource is created.
+	// The same fields are also added to the terraform ignore_changes hook, to
+	// avoid updating them after creation. This is useful for fields that are
+	// required on creation, but we do not desire to update them after creation,
+	// for example because of an external controller is managing them, like an
+	// autoscaler.
+	InitProvider       {{ .CRD.InitProviderType }} `json:"initProvider,omitempty"`
 }
 
 // {{ .CRD.Kind }}Status defines the observed state of {{ .CRD.Kind }}.

--- a/pkg/pipeline/templates/terraformed.go.tmpl
+++ b/pkg/pipeline/templates/terraformed.go.tmpl
@@ -72,6 +72,16 @@ import (
         return json.TFParser.Unmarshal(p, &tr.Spec.ForProvider)
     }
 
+    // GetInitParameters of this {{ .CRD.Kind }}
+    func (tr *{{ .CRD.Kind }}) GetInitParameters() (map[string]any, error) {
+        p, err := json.TFParser.Marshal(tr.Spec.InitProvider)
+        if err != nil {
+            return nil, err
+        }
+        base := map[string]any{}
+        return base, json.TFParser.Unmarshal(p, &base)
+    }
+
     // LateInitialize this {{ .CRD.Kind }} using its observed tfState.
     // returns True if there are any spec changes for the resource.
     func (tr *{{ .CRD.Kind }}) LateInitialize(attrs []byte) (bool, error) {

--- a/pkg/resource/fake/terraformed.go
+++ b/pkg/resource/fake/terraformed.go
@@ -42,7 +42,8 @@ func (o *Observable) GetAdditionalConnectionDetails(_ map[string]any) (map[strin
 
 // Parameterizable is mock Parameterizable.
 type Parameterizable struct {
-	Parameters map[string]any
+	Parameters     map[string]any
+	InitParameters map[string]any
 }
 
 // GetParameters is a mock.
@@ -54,6 +55,11 @@ func (p *Parameterizable) GetParameters() (map[string]any, error) {
 func (p *Parameterizable) SetParameters(data map[string]any) error {
 	p.Parameters = data
 	return nil
+}
+
+// GetInitParameters is a mock.
+func (p *Parameterizable) GetInitParameters() (map[string]any, error) {
+	return p.InitParameters, nil
 }
 
 // MetadataProvider is mock MetadataProvider.

--- a/pkg/resource/ignored.go
+++ b/pkg/resource/ignored.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2023 Upbound Inc.
+*/
+
+package resource
+
+import (
+	"fmt"
+	"sort"
+)
+
+// GetTerraformIgnoreChanges returns a sorted Terraform `ignore_changes`
+// lifecycle meta-argument expression by looking for differences between
+// the `initProvider` and `forProvider` maps. The ignored fields are the ones
+// that are present in initProvider, but not in forProvider.
+func GetTerraformIgnoreChanges(forProvider, initProvider map[string]any) []string {
+	ignored := getIgnoredFieldsMap("%s", forProvider, initProvider)
+	// sort the ignored fields so that we can compare them easily
+	sort.Strings(ignored)
+	return ignored
+}
+
+func getIgnoredFieldsMap(format string, forProvider, initProvider map[string]any) []string {
+	ignored := []string{}
+
+	for k := range initProvider {
+		if _, ok := forProvider[k]; !ok {
+			ignored = append(ignored, fmt.Sprintf(format, k))
+		} else {
+			// both are the same type so we dont need to check for forProvider type
+			if _, ok = initProvider[k].(map[string]any); ok {
+				ignored = append(ignored, getIgnoredFieldsMap(fmt.Sprintf(format, k)+"[%q]", forProvider[k].(map[string]any), initProvider[k].(map[string]any))...)
+			}
+			// if its an array, we need to check if its an array of maps or not
+			if _, ok = initProvider[k].([]any); ok {
+				ignored = append(ignored, getIgnoredFieldsArray(fmt.Sprintf(format, k), forProvider[k].([]any), initProvider[k].([]any))...)
+			}
+
+		}
+	}
+	return ignored
+}
+
+func getIgnoredFieldsArray(format string, forProvider, initProvider []any) []string {
+	ignored := []string{}
+	for i := range initProvider {
+		// Construct the full field path with array index and prefix.
+		fieldPath := fmt.Sprintf("%s[%d]", format, i)
+		if i < len(forProvider) {
+			if _, ok := initProvider[i].(map[string]any); ok {
+				ignored = append(ignored, getIgnoredFieldsMap(fieldPath+".%s", forProvider[i].(map[string]any), initProvider[i].(map[string]any))...)
+			}
+			if _, ok := initProvider[i].([]any); ok {
+				ignored = append(ignored, getIgnoredFieldsArray(fieldPath+"%s", forProvider[i].([]any), initProvider[i].([]any))...)
+			}
+		} else {
+			ignored = append(ignored, fieldPath)
+		}
+
+	}
+	return ignored
+}

--- a/pkg/resource/ignored_test.go
+++ b/pkg/resource/ignored_test.go
@@ -1,0 +1,298 @@
+/*
+Copyright 2023 Upbound Inc.
+*/
+
+package resource
+
+import (
+	_ "embed"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestGetIgnoredFields(t *testing.T) {
+	type args struct {
+		initProvider map[string]any
+		forProvider  map[string]any
+	}
+	type want struct {
+		ignored []string
+	}
+	cases := map[string]struct {
+		reason string
+		args
+		want
+	}{
+		"InitProviderEmpty": {
+			reason: "Should return the empty ignored fields when initProvider is empty",
+			args: args{
+				forProvider: map[string]any{
+					"singleField": "bob",
+				},
+			},
+			want: want{
+				ignored: []string{},
+			},
+		},
+		"ForProviderEmpty": {
+			reason: "Should return the ignored fields when forProvider is empty",
+			args: args{
+				initProvider: map[string]any{
+					"singleField": "bob",
+				},
+			},
+			want: want{
+				ignored: []string{"singleField"},
+			},
+		},
+		"SingleField": {
+			reason: "Should return the single ignored field when forProvider has a different field",
+			args: args{
+				initProvider: map[string]any{
+					"singleField": "bob",
+				},
+				forProvider: map[string]any{
+					"otherField": "bob",
+				},
+			},
+			want: want{
+				ignored: []string{"singleField"},
+			},
+		},
+		"SingleFieldSame": {
+			reason: "Should not return the single ignored field when forProvider has same fields",
+			args: args{
+				initProvider: map[string]any{
+					"singleField": "bob",
+				},
+				forProvider: map[string]any{
+					"singleField": "bob",
+				},
+			},
+			want: want{
+				ignored: []string{},
+			},
+		},
+		"NestedArrayField": {
+			reason: "Should return the ignored field when init and for provider have nested arrays with different fields",
+			args: args{
+				initProvider: map[string]any{
+					"array": []any{
+						map[string]any{
+							"singleField": "bob",
+							"same":        "same",
+						},
+					},
+				},
+				forProvider: map[string]any{
+					"array": []any{
+						map[string]any{
+							"otherField": "bob",
+							"same":       "not same value",
+						},
+					},
+				},
+			},
+			want: want{
+				ignored: []string{"array[0].singleField"},
+			},
+		},
+		"NestedArrayFieldMultiple": {
+			reason: "Should return the multiple ignored fields when init and for provider have nested arrays with different fields",
+			args: args{
+				initProvider: map[string]any{
+					"array": []any{
+						map[string]any{
+							"singleField": "bob",
+							"same":        "same",
+						},
+						map[string]any{
+							"nextField": "bob",
+						},
+					},
+				},
+				forProvider: map[string]any{
+					"array": []any{
+						map[string]any{
+							"otherField": "bob",
+							"same":       "not same value",
+						},
+					},
+				},
+			},
+			want: want{
+				ignored: []string{"array[0].singleField", "array[1]"},
+			},
+		},
+		"NestedArraySameField": {
+			reason: "Should not the ignored field when init and for provider have nested arrays with same fields",
+			args: args{
+				initProvider: map[string]any{
+					"array": []any{
+						map[string]any{
+							"same": "same",
+						},
+					},
+				},
+				forProvider: map[string]any{
+					"array": []any{
+						map[string]any{
+							"same": "not same value",
+						},
+					},
+				},
+			},
+			want: want{
+				ignored: []string{},
+			},
+		},
+		"NestedMapKey": {
+			reason: "Should return the ignored field when init and for provider have nested maps with different keys",
+			args: args{
+				initProvider: map[string]any{
+					"map": map[string]any{
+						"key":  "bob",
+						"same": "same",
+					},
+				},
+				forProvider: map[string]any{
+					"map": map[string]any{
+						"otherKey": "bob",
+						"same":     "not same value",
+					},
+				},
+			},
+			want: want{
+				ignored: []string{"map[\"key\"]"},
+			},
+		},
+		"NestedMapSameKey": {
+			reason: "Should not return the ignored field when init and for provider have nested maps with same keys",
+			args: args{
+				initProvider: map[string]any{
+					"map": map[string]any{
+						"same": "same",
+					},
+				},
+				forProvider: map[string]any{
+					"map": map[string]any{
+						"same": "not same value",
+					},
+				},
+			},
+			want: want{
+				ignored: []string{},
+			},
+		},
+		"MissingMapField": {
+			reason: "Should return the ignored field when init and for provider have different nested maps",
+			args: args{
+				initProvider: map[string]any{
+					"map": map[string]any{
+						"key": "bob",
+					},
+				},
+				forProvider: map[string]any{
+					"othermap": map[string]any{
+						"key": "bob",
+					},
+				},
+			},
+			want: want{
+				ignored: []string{"map"},
+			},
+		},
+		"MissingArrayField": {
+			reason: "Should return the ignored field when init and for provider have different nested arrays",
+			args: args{
+				initProvider: map[string]any{
+					"array": []any{
+						"bob",
+					},
+				},
+				forProvider: map[string]any{
+					"otherArray": []any{
+						"bob",
+					},
+				},
+			},
+			want: want{
+				ignored: []string{"array"},
+			},
+		},
+		"MissingMultipleFields": {
+			reason: "Should return the ignored fields when init and for provider have different multiple fields and nested fields",
+			args: args{
+				initProvider: map[string]any{
+					"singleField": "bob",
+					"array": []any{
+						map[string]any{
+							"singleField": "bob",
+							"secondField": "secondBob",
+							"sameKey":     "same",
+						},
+					},
+					"map": map[string]any{
+						"key":      "bob",
+						"otherKey": "otherBob",
+						"sameKey":  "same",
+					},
+				},
+				forProvider: map[string]any{
+					"otherField": "bob",
+					"array": []any{
+						map[string]any{
+							"otherField": "bob",
+							"sameKey":    "not same value",
+						},
+					},
+					"map": map[string]any{
+						"sameKey": "not same value",
+					},
+				},
+			},
+			want: want{
+				ignored: []string{"array[0].secondField", "array[0].singleField", "map[\"key\"]", "map[\"otherKey\"]", "singleField"},
+			},
+		},
+		"DoubleNestedArrayField": {
+			reason: "Should return the ignored field when init and for provider have deep nested arrays with different fields",
+			args: args{
+				initProvider: map[string]any{
+					"array": []any{
+						map[string]any{
+							"deepArray": []any{
+								map[string]any{
+									"singleField": "bob",
+								},
+							},
+						},
+					},
+				},
+				forProvider: map[string]any{
+					"array": []any{
+						map[string]any{
+							"deepArray": []any{
+								map[string]any{
+									"otherField": "bob",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: want{
+				ignored: []string{"array[0].deepArray[0].singleField"},
+			},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := GetTerraformIgnoreChanges(tc.args.forProvider, tc.args.initProvider)
+			if diff := cmp.Diff(tc.want.ignored, got); diff != "" {
+				t.Errorf("GetIgnorableFields() got = %v, want %v", got, tc.want.ignored)
+			}
+		})
+	}
+}

--- a/pkg/resource/interfaces.go
+++ b/pkg/resource/interfaces.go
@@ -20,6 +20,7 @@ type Observable interface {
 type Parameterizable interface {
 	GetParameters() (map[string]any, error)
 	SetParameters(map[string]any) error
+	GetInitParameters() (map[string]any, error)
 }
 
 // MetadataProvider provides Terraform metadata for the Terraform managed


### PR DESCRIPTION
<!--
Thank you for helping to improve Upjet!

Please read through https://git.io/fj2m9 if this is your first time opening a
Upjet pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Adds support for the new `initProvider` alpha feature, which is a part of the management
policies feature ([design](https://github.com/crossplane/crossplane/blob/master/design/one-pager-ignore-changes.md))

#### Runtime changes

As Upjet uses Terraform, it needs to create the `main.tf` file and workspace to run commands against it. It does it in the [Connect step](https://github.com/crossplane/crossplane-runtime/blob/8e87b2c47ee705f88b1224bff7b3eb8d1a071760/pkg/reconciler/managed/reconciler.go#L839) of the managed reconciler. The creation of the workspace already fills up the main.tf with the resource in question. This means that in the [Create](https://github.com/crossplane/crossplane-runtime/blob/8e87b2c47ee705f88b1224bff7b3eb8d1a071760/pkg/reconciler/managed/reconciler.go#L983) and [Update](https://github.com/crossplane/crossplane-runtime/blob/8e87b2c47ee705f88b1224bff7b3eb8d1a071760/pkg/reconciler/managed/reconciler.go#L1096) steps the passed resource is not actually the one which we Create/Update, as it has already been set in the `Connect`. This means that at the point of creating the `main.tf` file, we dont know if it will be used for Update or Create. So to fulfill the purpose of `initProvider` which is to have fields that are only used during Create, we need to use available TF tools - ignore_changes lifecycle hook, to mark the fields which should only be used for creation.

So if the management policies are enabled, when creating the FileProducer that holds the parameters of the `main.tf` file:
-  we calculate the fields which should be in the `ignore_changes` by going through the `spec.initProvider` and `spec.forProvider` , and looking for fields set in `spec.initProvider` but not in `spec.forProvider`
- we merge the `spec.initProvider` to `spec.forProvider` 

TODO:
currently `spec.initProvider` fields overwrite the `spec.forProvider` fields if both are set (slices and maps merge), due to how mergo works. In practice, this will be a problem if the user tries to set a field/map key in both. For our current use cases we dont have this situation, and it can be resolved easily by removing the `initProvider` conflicting key if the user wants to use `forProvider` for it. But we should take a look and fix that.
Issue: https://github.com/upbound/upjet/issues/240

#### Code generation

As mentioned in the design, added a new field in the resource `spec` , `spec.initProvider`. It will be used to set some fields of the `spec.forProvider` which should be used just in Create. We are not copying `spec.forProvider` 1:1 because some field types are not suited to be replaced during Create. 

The code generation recognizes a few different field types, based on resource config or terraform API information:
- **Identifier** fields, which are used to identify resources in addition to names. Good example is AWS `region`. Configured by provider options
- **Reference** fields, which allow to resolve cross resource references into some fields. The resolving of references takes place in the beginning of the managed reconciler loop. Configured by provider options. Example is:

```go
	// ARN of the certificate authority.
	// +crossplane:generate:reference:type=CertificateAuthority
	// +kubebuilder:validation:Optional
	CertificateAuthorityArn *string `json:"certificateAuthorityArn,omitempty" tf:"certificate_authority_arn,omitempty"`

	// Reference to a CertificateAuthority to populate certificateAuthorityArn.
	// +kubebuilder:validation:Optional
	CertificateAuthorityArnRef *v1.Reference `json:"certificateAuthorityArnRef,omitempty" tf:"-"`
```
- **Sensitive** fields, are those marked in terraform to contain sensitive information, such as passwords. We are replacing them with secret references to avoid having sensitive information in resource yaml's. 
- **Regular** fields, are all other fields for the resource, generated through parsing the fields of the terraform resource schema.

For `initProvider` we are just interested in the **Regular** fields. Because:
- Identifiers specify the resource, we cannot create the resource in `region: us-west-1` and expect to later managed it in `us-east-3`.
- References because they are references to other resources. Not sure if there is an use case where a resource depends on one resource during creation, but during lifetime another. It can easily be changed in the forProvider if needed. 
- Sensitive fields similarly to above, as they are in the end also references to secrets. 
- fields which have a `tf: "-"` tag. Its the fields above, but added it for precaution, as we are merging initProvider and forProvider and calculating `ignore_changes` based on the terraform fields.

We could in theory add reference and sensitive fields to the `initProvider` but as there is not use case for that and their usage could incur bugs, I would rather leave them out unless they are needed. 

#### CEL rules

All required `spec.forProvider` fields, which are also `spec.initProvider` fields are now optional, because they can be replaced with `initProvider` fields. We already have a functionality to mark the top non-identifier required fields as optional and set CEL rules to check if they are set, or if ObserveOnly managementPolicy is [active](https://github.com/upbound/upjet/blob/main/pkg/types/builder.go#L134). This only affects the top level fields, as it can easily mark required nested structs. 
```yaml
// +kubebuilder:validation:XValidation:rule="!('*' in self.managementPolicies || 'Create' in self.managementPolicies || 'Update' in self.managementPolicies)",message="%s is a required parameter"
```

Now because of initProvider, we can also check if the field is in `spec.initProvider`

```yaml
// +kubebuilder:validation:XValidation:rule="!('*' in self.managementPolicies || 'Create' in self.managementPolicies || 'Update' in self.managementPolicies || has(self.forProvider.%s))",message="%s is a required parameter"
```

But because now we merge required nested structs from `spec.initProvider` to `spec.forProvider` we need to expand the CEL rules to also mark the nested fields as required either in `spec.initProvider` or `spec.forProvider`. This is something still TODO, issue: https://github.com/upbound/upjet/issues/239. 


<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Upjet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #225 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

The generation code has been tested with [generating provider aws](https://github.com/upbound/provider-aws/pull/785/commits/fe906d63156b015775b12c48b8ee4ce173f251e4)

Tested with provider-aws([PR](https://github.com/upbound/provider-aws/pull/785)), creating a Node Group from the [design example](https://github.com/crossplane/crossplane/blob/master/design/one-pager-ignore-changes.md#eks-nodegroup). 
with some added fields to test the ignore_changes generation:

```yaml
apiVersion: eks.aws.upbound.io/v1beta1
kind: NodeGroup
metadata:
  name: sample-eks-ng
spec:
  managementPolicies: ["Observe", "Create", "Update", "Delete"]
  initProvider:
    tags:
      someTag: tag
    forceUpdateVersion: false
    scalingConfig:
      - desiredSize: 1
  forProvider:
    clusterNameRef:
      name: sample-eks-cluster
    nodeRoleArnRef:
      name: sample-node-role
    region: us-west-1
    scalingConfig:
      - maxSize: 4
        minSize: 1
    subnetIdRefs:
      - name: sample-subnet1
      - name: sample-subnet2
```

Resulting `main.tf.json`:
```json
"resource": {
    "aws_eks_node_group": {
      "sample-eks-ng": {
        "cluster_name": "sample-eks-cluster",
        "force_update_version": false,
        "lifecycle": {
          "ignore_changes": [
            "force_update_version",
            "scaling_config[0].desired_size",
            "tags[\"someTag\"]"
          ],
          "prevent_destroy": true
        },
        "node_group_name": "sample-eks-ng",
        "node_role_arn": "arn:aws:iam::609897127049:role/sample-node-role",
        "scaling_config": [
          {
            "desired_size": 1,
            "max_size": 4,
            "min_size": 1
          }
        ],
        "subnet_ids": [
          "subnet-034a2e1a7ffdd3e7f",
          "subnet-044de3d67a78caa77"
        ],
        "tags": {
          "crossplane-kind": "nodegroup.eks.aws.upbound.io",
          "crossplane-name": "sample-eks-ng",
          "crossplane-providerconfig": "default",
          "someTag": "tag"
        }
      }
    }
  },
  "terraform": {
    "required_providers": {
      "aws": {
        "source": "hashicorp/aws",
        "version": "4.56.0"
      }
    }
  }
```

DynamoDB Table
```yaml
spec:
  managementPolicies: ["Observe", "Create", "Update", "Delete"]
  initProvider:
    writeCapacity: 20
    readCapacity: 19
  forProvider:
    region: us-west-1
    attribute:
    - name: UserId
      type: S
    - name: GameTitle
      type: S
    - name: TopScore
      type: "N"
    billingMode: PROVISIONED
    globalSecondaryIndex:
    - hashKey: GameTitle
      name: GameTitleIndex
      nonKeyAttributes:
      - UserId
      projectionType: INCLUDE
      rangeKey: TopScore
      readCapacity: 10
      writeCapacity: 10
    hashKey: UserId
    rangeKey: GameTitle
```
```json
"resource": {
    "aws_dynamodb_table": {
      "example": {
        "attribute": [
          {
            "name": "UserId",
            "type": "S"
          },
          {
            "name": "GameTitle",
            "type": "S"
          },
          {
            "name": "TopScore",
            "type": "N"
          }
        ],
        "billing_mode": "PROVISIONED",
        "global_secondary_index": [
          {
            "hash_key": "GameTitle",
            "name": "GameTitleIndex",
            "non_key_attributes": [
              "UserId"
            ],
            "projection_type": "INCLUDE",
            "range_key": "TopScore",
            "read_capacity": 10,
            "write_capacity": 10
          }
        ],
        "hash_key": "UserId",
        "lifecycle": {
          "ignore_changes": [
            "read_capacity",
            "write_capacity"
          ],
          "prevent_destroy": true
        },
        "name": "example",
        "range_key": "GameTitle",
        "read_capacity": 19,
        "tags": {
          "crossplane-kind": "table.dynamodb.aws.upbound.io",
          "crossplane-name": "example",
          "crossplane-providerconfig": "default"
        },
        "write_capacity": 20
      }
    }
  },
```

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
