### PR TITLE
Explicitly Queue a Reconcile Request if a Shared Provider has Expired

### DIFF
--- a/pkg/controller/api.go
+++ b/pkg/controller/api.go
@@ -41,6 +41,10 @@ const (
 	errReconcileRequestFmt = "cannot request the reconciliation of the resource %s/%s after an async %s"
 )
 
+const (
+	rateLimiterCallback = "asyncCallback"
+)
+
 var _ CallbackProvider = &APICallbacks{}
 
 // APISecretClient is a client for getting k8s secrets
@@ -116,11 +120,11 @@ func (ac *APICallbacks) callbackFn(name, op string, requeue bool) terraform.Call
 			case err != nil:
 				// TODO: use the errors.Join from
 				// github.com/crossplane/crossplane-runtime.
-				if ok := ac.eventHandler.RequestReconcile(name); !ok {
+				if ok := ac.eventHandler.RequestReconcile(rateLimiterCallback, name, nil); !ok {
 					return errors.Errorf(errReconcileRequestFmt, tr.GetObjectKind().GroupVersionKind().String(), name, op)
 				}
 			default:
-				ac.eventHandler.Forget(name)
+				ac.eventHandler.Forget(rateLimiterCallback, name)
 			}
 		}
 		return uErr

--- a/pkg/pipeline/templates/controller.go.tmpl
+++ b/pkg/pipeline/templates/controller.go.tmpl
@@ -39,7 +39,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	ac := tjcontroller.NewAPICallbacks(mgr, xpresource.ManagedKind({{ .TypePackageAlias }}{{ .CRD.Kind }}_GroupVersionKind), tjcontroller.WithEventHandler(o.EventHandler))
 	{{- end}}
 	opts := []managed.ReconcilerOption{
-		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), o.WorkspaceStore, o.SetupFn, o.Provider.Resources["{{ .ResourceType }}"], tjcontroller.WithLogger(o.Logger),
+		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), o.WorkspaceStore, o.SetupFn, o.Provider.Resources["{{ .ResourceType }}"], tjcontroller.WithLogger(o.Logger), tjcontroller.WithConnectorEventHandler(o.EventHandler),
 			{{- if .UseAsync }}
 			tjcontroller.WithCallbackProvider(ac),
 			{{- end}}

--- a/pkg/terraform/errors/errors.go
+++ b/pkg/terraform/errors/errors.go
@@ -161,3 +161,26 @@ func IsPlanFailed(err error) bool {
 	r := &planFailed{}
 	return errors.As(err, &r)
 }
+
+type retrySchedule struct {
+	invocationCount int
+	ttl             int
+}
+
+func NewRetryScheduleError(invocationCount, ttl int) error {
+	return &retrySchedule{
+		invocationCount: invocationCount,
+		ttl:             ttl,
+	}
+}
+
+func (r *retrySchedule) Error() string {
+	return fmt.Sprintf("native provider reuse budget has been exceeded: invocationCount: %d, ttl: %d", r.invocationCount, r.ttl)
+}
+
+// IsRetryScheduleError returns whether the error is a retry error
+// for the scheduler.
+func IsRetryScheduleError(err error) bool {
+	r := &retrySchedule{}
+	return errors.As(err, &r)
+}

--- a/pkg/terraform/provider_runner.go
+++ b/pkg/terraform/provider_runner.go
@@ -94,46 +94,46 @@ type SharedProviderOption func(runner *SharedProvider)
 
 // WithNativeProviderArgs are the arguments to be passed to the native provider
 func WithNativeProviderArgs(args ...string) SharedProviderOption {
-	return func(sr *SharedProvider) {
-		sr.nativeProviderArgs = args
+	return func(sp *SharedProvider) {
+		sp.nativeProviderArgs = args
 	}
 }
 
 // WithNativeProviderExecutor sets the process executor to be used
 func WithNativeProviderExecutor(e exec.Interface) SharedProviderOption {
-	return func(sr *SharedProvider) {
-		sr.executor = e
+	return func(sp *SharedProvider) {
+		sp.executor = e
 	}
 }
 
 // WithProtocolVersion sets the gRPC protocol version in use between
 // the Terraform CLI and the native provider.
 func WithProtocolVersion(protocolVersion int) SharedProviderOption {
-	return func(sr *SharedProvider) {
-		sr.protocolVersion = protocolVersion
+	return func(sp *SharedProvider) {
+		sp.protocolVersion = protocolVersion
 	}
 }
 
 // WithNativeProviderPath configures the Terraform provider executable path
 // for the runner.
 func WithNativeProviderPath(p string) SharedProviderOption {
-	return func(sr *SharedProvider) {
-		sr.nativeProviderPath = p
+	return func(sp *SharedProvider) {
+		sp.nativeProviderPath = p
 	}
 }
 
 // WithNativeProviderName configures the Terraform provider name
 // for the runner.
 func WithNativeProviderName(n string) SharedProviderOption {
-	return func(sr *SharedProvider) {
-		sr.nativeProviderName = n
+	return func(sp *SharedProvider) {
+		sp.nativeProviderName = n
 	}
 }
 
 // WithNativeProviderLogger configures the logger for the runner.
 func WithNativeProviderLogger(logger logging.Logger) SharedProviderOption {
-	return func(sr *SharedProvider) {
-		sr.logger = logger
+	return func(sp *SharedProvider) {
+		sp.logger = logger
 	}
 }
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Upjet!

Please read through https://git.io/fj2m9 if this is your first time opening a
Upjet pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Upjet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #192 

We currently return an error if a [terraform.SharedProvider](https://github.com/upbound/upjet/blob/cd958ec5d17665415fe1ca31724bb8ffada9e235/pkg/terraform/provider_runner.go#L79) has already expired and an external client requests service from the expired shared provider. This results in the MR being reconciled by the external client to acquire a `Synced: False` status condition. This is a temporary situation that's resolved once the expired shared provider is drained and the [terraform.SharedProviderScheduler](https://github.com/upbound/upjet/blob/cd958ec5d17665415fe1ca31724bb8ffada9e235/pkg/terraform/provider_scheduler.go#L117) replaces it.

However, until the shared provider is replaced, the MRs entering into the `Synced: False` state become confusing. Before the `handler.EventHandler` implementation from #231, we had to return an error to the managed reconciler to requeue a timely reconciliation request. However, we can now explicitly requeue an exponentially backed-off reconciliation request so that the external client will retry to get service from the provider in a timely manner without having to wait for the poll period (default 10 min for the official providers) and without forcing the MR falling into the `Synced: False` state.

The external client will retry to schedule a shared runner up to 20 times without erroring, exponentially backing-off after each failure. And after this initial 20 retries, it will report the error to the managed reconciler and keep trying.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Tested via https://github.com/upbound/provider-aws/pull/805.

[contribution process]: https://git.io/fj2m9
