### PR TITLE
Fix config.Provider.RootGroup field docs

### DIFF
--- a/docs/generating-a-provider.md
+++ b/docs/generating-a-provider.md
@@ -326,10 +326,10 @@ Now let's test our generated resources.
 
    ```bash
    NAME                                                   READY   SYNCED   EXTERNAL-NAME                     AGE
-   branch.branch.github.jet.crossplane.io/hello-upjet   True    True     hello-crossplane:hello-upjet   89s
+   branch.branch.github.upbound.io/hello-upjet   True    True     hello-crossplane:hello-upjet   89s
 
    NAME                                                             READY   SYNCED   EXTERNAL-NAME      AGE
-   repository.repository.github.jet.crossplane.io/hello-crossplane   True    True     hello-crossplane   89s
+   repository.repository.github.upbound.io/hello-crossplane   True    True     hello-crossplane   89s
    ```
 
    Verify that repo `hello-crossplane` and branch `hello-upjet` created under

--- a/docs/images/upjet-externalname.excalidraw
+++ b/docs/images/upjet-externalname.excalidraw
@@ -188,12 +188,12 @@
       "updated": 1640767155602,
       "fontSize": 16,
       "fontFamily": 3,
-      "text": "apiVersion: sql.azure.jet.crossplane.io/v1alpha1\nkind: Server\nmetadata:\n  name: myserver\n  annotations:\n    crossplane.io/external-name: myserver\nspec:\n  forProvider:\n    ...\n    resourceGroupNameRef:\n      name: myresourcegroup\n  providerConfigRef:\n    name: example",
+      "text": "apiVersion: sql.azure.upbound.io/v1alpha1\nkind: Server\nmetadata:\n  name: myserver\n  annotations:\n    crossplane.io/external-name: myserver\nspec:\n  forProvider:\n    ...\n    resourceGroupNameRef:\n      name: myresourcegroup\n  providerConfigRef:\n    name: example",
       "baseline": 243,
       "textAlign": "left",
       "verticalAlign": "top",
       "containerId": null,
-      "originalText": "apiVersion: sql.azure.jet.crossplane.io/v1alpha1\nkind: Server\nmetadata:\n  name: myserver\n  annotations:\n    crossplane.io/external-name: myserver\nspec:\n  forProvider:\n    ...\n    resourceGroupNameRef:\n      name: myresourcegroup\n  providerConfigRef:\n    name: example"
+      "originalText": "apiVersion: sql.azure.upbound.io/v1alpha1\nkind: Server\nmetadata:\n  name: myserver\n  annotations:\n    crossplane.io/external-name: myserver\nspec:\n  forProvider:\n    ...\n    resourceGroupNameRef:\n      name: myresourcegroup\n  providerConfigRef:\n    name: example"
     },
     {
       "id": "5TV10V0jD_m7Ba68DZ2fG",

--- a/pkg/config/provider.go
+++ b/pkg/config/provider.go
@@ -61,8 +61,8 @@ type Provider struct {
 	TerraformResourcePrefix string
 
 	// RootGroup is the root group that all CRDs groups in the provider are based
-	// on, e.g. "aws.jet.crossplane.io".
-	// Defaults to "<TerraformResourcePrefix>.jet.crossplane.io".
+	// on, e.g. "aws.upbound.io".
+	// Defaults to "<TerraformResourcePrefix>.upbound.io".
 	RootGroup string
 
 	// ShortName is the short name of the provider. Typically, added as a CRD

--- a/pkg/pipeline/run.go
+++ b/pkg/pipeline/run.go
@@ -30,7 +30,7 @@ func Run(pc *config.Provider, rootDir string) { // nolint:gocyclo
 
 	// Group resources based on their Group and API Versions.
 	// An example entry in the tree would be:
-	// ec2.awsjet.crossplane.io -> v1alpha1 -> aws_vpc
+	// ec2.aws.upbound.io -> v1beta1 -> aws_vpc
 	resourcesGroups := map[string]map[string]map[string]*config.Resource{}
 	for name, resource := range pc.Resources {
 		group := pc.RootGroup


### PR DESCRIPTION
<!--
Thank you for helping to improve Upjet!

Please read through https://git.io/fj2m9 if this is your first time opening a
Upjet pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Upjet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes the `config.Provider.RootGroup` field docs so that it reads now as:
```golang
	// RootGroup is the root group that all CRDs groups in the provider are based
	// on, e.g. "aws.upbound.io".
	// Defaults to "<TerraformResourcePrefix>.upbound.io".
```

It also replaces some `jet.crossplane.io` with `upbound.io` throughout the repository.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
`make reviewable`

[contribution process]: https://git.io/fj2m9
