### PR TITLE
Revert "feat(doc-generator): fix generation examples for provider-vault"

### DIFF
--- a/pkg/registry/meta.go
+++ b/pkg/registry/meta.go
@@ -187,11 +187,10 @@ func (r *Resource) findExampleBlock(file *hcl.File, blocks hclsyntax.Blocks, res
 				continue
 			}
 
-			switch {
-			case suffixMatch(b.Labels[0], *resourceName, 1) || strings.Contains(*resourceName, b.Labels[0]):
+			if suffixMatch(b.Labels[0], *resourceName, 1) {
 				*resourceName = b.Labels[0]
 				exactMatch = true
-			default:
+			} else {
 				dependencies[depKey] = m
 				continue
 			}


### PR DESCRIPTION
Reverts upbound/upjet#238

Turns out that the generators for the AWS provider:
```
❯ git status apis
On branch bump-upjet
Your branch is up to date with 'origin/bump-upjet'.

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
        modified:   apis/lightsail/v1beta1/zz_bucket_types.go

no changes added to commit (use "git add" and/or "git commit -a")
```

For provider-gcp:
```
❯ git status apis
On branch bump-upjet
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
        modified:   apis/cloudplatform/v1beta1/zz_serviceaccount_types.go
        modified:   apis/cloudplatform/v1beta1/zz_serviceaccountkey_types.go
        modified:   apis/kms/v1beta1/zz_keyring_types.go
        modified:   apis/kms/v1beta1/zz_keyringimportjob_types.go

no changes added to commit (use "git add" and/or "git commit -a")
```

I did not check provider-{azure,azuread}.