### PR TITLE
feat(docs): fix doc generation

### DIFF
--- a/pkg/registry/meta.go
+++ b/pkg/registry/meta.go
@@ -173,7 +173,7 @@ func convertManifest2JSON(file *hcl.File, b *hclsyntax.Block) (string, error) {
 	return out.String(), nil
 }
 
-func (r *Resource) findExampleBlock(file *hcl.File, blocks hclsyntax.Blocks, resourceName *string, exactMatch bool) error {
+func (r *Resource) findExampleBlock(file *hcl.File, blocks hclsyntax.Blocks, resourceName *string, exactMatch bool) error { //nolint:gocyclo
 	dependencies := make(map[string]string)
 	for _, b := range blocks {
 		depKey := fmt.Sprintf("%s.%s", b.Labels[0], b.Labels[1])

--- a/pkg/registry/meta.go
+++ b/pkg/registry/meta.go
@@ -187,7 +187,7 @@ func (r *Resource) findExampleBlock(file *hcl.File, blocks hclsyntax.Blocks, res
 				continue
 			}
 
-			if suffixMatch(b.Labels[0], *resourceName, 1) {
+			if suffixMatch(b.Labels[0], *resourceName, 1) || (strings.Contains(*resourceName, b.Labels[0]) && strings.Count(*resourceName, "_") == strings.Count(b.Labels[0], "_")) {
 				*resourceName = b.Labels[0]
 				exactMatch = true
 			} else {


### PR DESCRIPTION
<!--
Thank you for helping to improve Upjet!

Please read through https://git.io/fj2m9 if this is your first time opening a
Upjet pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
follow up for 
https://github.com/upbound/upjet/pull/238
and revert from 
https://github.com/upbound/upjet/pull/244

the page_title is different for provider-vault then to other providers
page_title: "Vault: vault_ad_secret_backend_library resource"
for that reason i added a small code path to make the example generation working


<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Upjet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
rerun make generate in upbound official-providers for aws, gcp and azure

https://github.com/upbound/provider-aws/pull/806 (we have a small diff in `config/provider-metadata.yaml `because some markdown pages using ' instead of " and the new version fixed this)
https://github.com/upbound/provider-gcp/pull/347
https://github.com/upbound/provider-azure/pull/502
https://github.com/crossplane-contrib/provider-pagerduty/pull/18  (we have a small diff in `config/provider-metadata.yaml `because some markdown pages using ' instead of " and the new version fixed this)

https://github.com/upbound/provider-vault/pull/7/files
here we see that all examples now generated:

```
ls -ali examples-generated 
total 0
6199735 drwxr-x---@ 36 haarchri  staff  1152 Aug  1 18:47 .
5427646 drwxr-xr-x  28 haarchri  staff   896 Aug  1 18:47 ..
6199811 drwxr-x---@  4 haarchri  staff   128 Aug  1 18:47 ad
6199849 drwxr-x---@  3 haarchri  staff    96 Aug  1 18:47 alicloud
6199757 drwxr-x---@  5 haarchri  staff   160 Aug  1 18:47 approle
6199749 drwxr-x---@  3 haarchri  staff    96 Aug  1 18:47 audit
6199865 drwxr-x---@  3 haarchri  staff    96 Aug  1 18:47 auth
6199745 drwxr-x---@ 13 haarchri  staff   416 Aug  1 18:47 aws
6199773 drwxr-x---@  6 haarchri  staff   192 Aug  1 18:47 azure
6199798 drwxr-x---@  4 haarchri  staff   128 Aug  1 18:47 consul
6199817 drwxr-x---@  6 haarchri  staff   192 Aug  1 18:47 database
6199845 drwxr-x---@  3 haarchri  staff    96 Aug  1 18:47 egp
6199800 drwxr-x---@  7 haarchri  staff   224 Aug  1 18:47 gcp
6199842 drwxr-x---@  4 haarchri  staff   128 Aug  1 18:47 generic
6199793 drwxr-x---@  5 haarchri  staff   160 Aug  1 18:47 github
6199761 drwxr-x---@ 22 haarchri  staff   704 Aug  1 18:47 identity
6199823 drwxr-x---@  4 haarchri  staff   128 Aug  1 18:47 jwt
6199743 drwxr-x---@  5 haarchri  staff   160 Aug  1 18:47 kmip
6199826 drwxr-x---@  6 haarchri  staff   192 Aug  1 18:47 kubernetes
6199765 drwxr-x---@  5 haarchri  staff   160 Aug  1 18:47 kv
6199809 drwxr-x---@  3 haarchri  staff    96 Aug  1 18:47 managed
6199747 drwxr-x---@  6 haarchri  staff   192 Aug  1 18:47 mfa
6199795 drwxr-x---@  4 haarchri  staff   128 Aug  1 18:47 mongodbatlas
6199740 drwxr-x---@  4 haarchri  staff   128 Aug  1 18:47 nomad
6199769 drwxr-x---@  3 haarchri  staff    96 Aug  1 18:47 password
6199736 drwxr-x---@ 11 haarchri  staff   352 Aug  1 18:47 pki
6199771 drwxr-x---@  4 haarchri  staff   128 Aug  1 18:47 quota
6199753 drwxr-x---@  4 haarchri  staff   128 Aug  1 18:47 rabbitmq
6199738 drwxr-x---@  4 haarchri  staff   128 Aug  1 18:47 raft
6199755 drwxr-x---@  3 haarchri  staff    96 Aug  1 18:47 rgp
6199759 drwxr-x---@  4 haarchri  staff   128 Aug  1 18:47 ssh
6199763 drwxr-x---@  5 haarchri  staff   160 Aug  1 18:47 terraform
6199791 drwxr-x---@  3 haarchri  staff    96 Aug  1 18:47 token
6199767 drwxr-x---@  6 haarchri  staff   192 Aug  1 18:47 transform
6199782 drwxr-x---@  3 haarchri  staff    96 Aug  1 18:47 transit
6199751 drwxr-x---@  7 haarchri  staff   224 Aug  1 18:47 vault
```

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
