### PR TITLE
Set a default EventHandler if the provider's main module does not supply one

### DIFF
--- a/pkg/pipeline/templates/setup.go.tmpl
+++ b/pkg/pipeline/templates/setup.go.tmpl
@@ -8,6 +8,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/upbound/upjet/pkg/controller"
+	"github.com/upbound/upjet/pkg/controller/handler"
 
 	{{ .Imports }}
 )
@@ -15,6 +16,11 @@ import (
 // Setup{{ .Group }} creates all controllers with the supplied logger and adds them to
 // the supplied manager.
 func Setup{{ .Group }}(mgr ctrl.Manager, o controller.Options) error {
+	// set the default event handler if the provider's main module did not
+	// set one.
+	if o.EventHandler == nil {
+		o.EventHandler = handler.NewEventHandler()
+	}
 	for _, setup := range []func(ctrl.Manager, controller.Options) error{
 		{{- range $alias := .Aliases }}
 		{{ $alias }}Setup,


### PR DESCRIPTION
<!--
Thank you for helping to improve Upjet!

Please read through https://git.io/fj2m9 if this is your first time opening a
Upjet pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Upjet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
While updating the upjet dependency to the main HEAD, @haarchri  figured out that the recently introduced changes with https://github.com/upbound/upjet/pull/231/ are not backwards-compatible. This PR makes those changes backwards-compatible by setting a default event handler if one is not already set by the provider's main module. The provider may set the event handler with something like:
```go
o := tjcontroller.Options{
		Options: xpcontroller.Options{
			Logger:                  log,
			GlobalRateLimiter:       ratelimiter.NewGlobal(*maxReconcileRate),
			PollInterval:            *pollInterval,
			MaxConcurrentReconciles: *maxReconcileRate,
			Features:                &feature.Flags{},
		},
		Provider:       config.GetProvider(),
		SetupFn:        clients.TerraformSetupBuilder(*terraformVersion, *nativeProviderSource, *providerVersion),
		WorkspaceStore: terraform.NewWorkspaceStore(log, terraform.WithDisableInit(len(*nativeProviderPath) != 0), terraform.WithProcessReportInterval(*pollInterval), terraform.WithFeatures(featureFlags)),
		EventHandler: handler.NewEventHandler(),
	}
```

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Tested against [`crossplane-contrib/provider-pagerduty`](https://github.com/crossplane-contrib/provider-pagerduty).

[contribution process]: https://git.io/fj2m9
