### PR TITLE
Add some common utility functions to migration framework

### DIFF
--- a/pkg/migration/converter.go
+++ b/pkg/migration/converter.go
@@ -260,7 +260,9 @@ func toPackageLock(u unstructured.Unstructured) (*xppkgv1beta1.Lock, error) {
 	return lock, nil
 }
 
-// ConvertComposedTemplatePatchesMap converts the composed templates with given conversion map
+// ConvertComposedTemplatePatchesMap converts the composed templates with given conversionMap
+// Key of the conversionMap points to the source field
+// Value of the conversionMap points to the target field
 func ConvertComposedTemplatePatchesMap(sourceTemplate xpv1.ComposedTemplate, conversionMap map[string]string) []xpv1.Patch {
 	var patchesToAdd []xpv1.Patch
 	for _, p := range sourceTemplate.Patches {

--- a/pkg/migration/converter.go
+++ b/pkg/migration/converter.go
@@ -15,9 +15,6 @@
 package migration
 
 import (
-	"fmt"
-	"strings"
-
 	"github.com/crossplane/crossplane-runtime/pkg/fieldpath"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	xpv1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
@@ -263,33 +260,7 @@ func toPackageLock(u unstructured.Unstructured) (*xppkgv1beta1.Lock, error) {
 	return lock, nil
 }
 
-func ConvertComposedTemplateTags(sourceTemplate xpv1.ComposedTemplate, value string, key string) ([]xpv1.Patch, error) {
-	var patchesToAdd []xpv1.Patch
-	for _, p := range sourceTemplate.Patches {
-		if p.ToFieldPath != nil {
-			if strings.HasPrefix(*p.ToFieldPath, "spec.forProvider.tags") {
-				u, err := FromRawExtension(sourceTemplate.Base)
-				if err != nil {
-					return nil, errors.Wrap(err, "failed to convert ComposedTemplate")
-				}
-				paved := fieldpath.Pave(u.Object)
-				key, err := paved.GetString(strings.ReplaceAll(*p.ToFieldPath, value, key))
-				if err != nil {
-					return nil, errors.Wrap(err, "failed to get value from paved")
-				}
-				s := fmt.Sprintf(`spec.forProvider.tags["%s"]`, key)
-				patchesToAdd = append(patchesToAdd, xpv1.Patch{
-					FromFieldPath: p.FromFieldPath,
-					ToFieldPath:   &s,
-					Transforms:    p.Transforms,
-					Policy:        p.Policy,
-				})
-			}
-		}
-	}
-	return patchesToAdd, nil
-}
-
+// ConvertComposedTemplatePatchesMap converts the composed templates with given conversion map
 func ConvertComposedTemplatePatchesMap(sourceTemplate xpv1.ComposedTemplate, conversionMap map[string]string) []xpv1.Patch {
 	var patchesToAdd []xpv1.Patch
 	for _, p := range sourceTemplate.Patches {

--- a/pkg/migration/registry.go
+++ b/pkg/migration/registry.go
@@ -473,6 +473,8 @@ func (d *delegatingConverter) ComposedTemplate(sourceTemplate xpv1.ComposedTempl
 
 // DefaultCompositionConverter is a generic composition converter
 // conversionMap: is fieldpath map for conversion
+// Key of the conversionMap points to the source field
+// Value of the conversionMap points to the target field
 // Example: "spec.forProvider.assumeRolePolicyDocument": "spec.forProvider.assumeRolePolicy",
 // fns are functions that manipulate the patchsets
 func DefaultCompositionConverter(conversionMap map[string]string, fns ...func(sourceTemplate xpv1.ComposedTemplate) ([]xpv1.Patch, error)) ComposedTemplateConversionFn {


### PR DESCRIPTION
### Description of your changes

This PR adds some common utility functions to migration framework.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

[contribution process]: https://git.io/fj2m9
