### PR TITLE
revert leaving optional for required init fields

### DIFF
--- a/pkg/types/builder.go
+++ b/pkg/types/builder.go
@@ -306,13 +306,13 @@ func newTopLevelRequiredParam(path string, includeInit bool) *topLevelRequiredPa
 }
 
 func (r *resource) addParameterField(f *Field, field *types.Var) {
-	req := !f.Schema.Optional
+	requiredBySchema := !f.Schema.Optional
 	// Note(turkenh): We are collecting the top level required parameters that
 	// are not identifier fields. This is for generating CEL validation rules for
 	// those parameters and not to require them if the management policy is set
 	// Observe Only. In other words, if we are not creating or managing the
 	// resource, we don't need to provide those parameters which are:
-	// - req => required
+	// - requiredBySchema => required
 	// - !f.Identifier => not identifiers - i.e. region, zone, etc.
 	// - len(f.CanonicalPaths) == 1 => top level, i.e. not a nested field
 	// TODO (lsviben): We should add CEL rules for all required fields,
@@ -320,17 +320,18 @@ func (r *resource) addParameterField(f *Field, field *types.Var) {
 	// fields now optional. CEL rules should check if a field is
 	// present either in forProvider or initProvider.
 	// https://github.com/upbound/upjet/issues/239
-	if req && !f.Identifier && len(f.CanonicalPaths) == 1 {
-		req = false
+	if requiredBySchema && !f.Identifier && len(f.CanonicalPaths) == 1 {
+		requiredBySchema = false
 		// If the field is not a terraform field, we should not require it in init,
 		// as it is not an initProvider field.
 		r.topLevelRequiredParams = append(r.topLevelRequiredParams, newTopLevelRequiredParam(f.TransformedName, f.TFTag != "-"))
 	}
 
-	// Note(lsviben): Only fields which are not also initProvider fields should be required.
-	paramRequired := req && !f.isInit()
-	f.Comment.Required = pointer.Bool(paramRequired)
-	if paramRequired {
+	// Note(lsviben): Only fields which are not also initProvider fields should have a required kubebuilder comment.
+	f.Comment.Required = pointer.Bool(requiredBySchema && !f.isInit())
+
+	// For removing omitempty tag from json tag, we are just checking if the field is required by the schema.
+	if requiredBySchema {
 		// Required fields should not have omitempty tag in json tag.
 		// TODO(muvaf): This overrides user intent if they provided custom
 		// JSON tag.


### PR DESCRIPTION
<!--
Thank you for helping to improve Upjet!

Please read through https://git.io/fj2m9 if this is your first time opening a
Upjet pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Related to https://github.com/upbound/provider-gcp/issues/355 .

In https://github.com/upbound/upjet/pull/237, the required fields in `spec.forProvider` were set as optional due to them being replacable by the fields in `spec.initProvider` (just the fields that are in `spec.initProvider` not all required fields like identifiers).

This also added, or rather didnt remove, the `omitempty` json tag for those fields. This causes boolean fields to not be properly late-initialized, which in turn causes the resource to be stuck in `Synced: FALSE` status as it does not have all the required fields.

So this PR reverts the change in which the `omitempty` tag was not being removed for fields that are required && initProvider field. Instead it removes the `omitempty` for all fields that are required.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Upjet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Ran `make generate` on provider-gcp and tested running locally with a kind cluster.

The resource created is the cluster from the bug issue: https://github.com/upbound/provider-gcp/issues/355#issuecomment-1672889502
```yaml
apiVersion: container.gcp.upbound.io/v1beta1
kind: Cluster
metadata:
  annotations:
    meta.upbound.io/example-id: container/v1beta1/cluster
  labels:
    testing.upbound.io/example-name: cluster
  name: cluster
spec:
  forProvider:
    location: europe-north1
    ipAllocationPolicy:
      - {}
    enableAutopilot: true
```

The result is:
```bash
kubectl get -f cluster.yaml 
NAME      READY   SYNCED   EXTERNAL-NAME   AGE
cluster   True    True     cluster         89m
```

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
