### PR TITLE
Fixes the requeueing bug which requeues a reconcile request in a wrong workqueue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,9 @@
 PROJECT_NAME := upjet
 PROJECT_REPO := github.com/upbound/$(PROJECT_NAME)
 
-GOLANGCILINT_VERSION ?= 1.53.3
+# GOLANGCILINT_VERSION is inherited from build submodule by default.
+# Uncomment below if you need to override the version.
+# GOLANGCILINT_VERSION ?= 1.54.0
 GO_REQUIRED_VERSION ?= 1.20
 
 PLATFORMS ?= linux_amd64 linux_arm64

--- a/pkg/controller/external.go
+++ b/pkg/controller/external.go
@@ -125,7 +125,7 @@ func (c *Connector) Connect(ctx context.Context, mg xpresource.Managed) (managed
 		providerHandle:    ws.ProviderHandle,
 		eventHandler:      c.eventHandler,
 		kube:              c.kube,
-		logger:            c.logger.WithValues("uid", mg.GetUID()),
+		logger:            c.logger.WithValues("uid", mg.GetUID(), "name", mg.GetName(), "gvk", mg.GetObjectKind().GroupVersionKind().String()),
 	}, nil
 }
 

--- a/pkg/controller/options.go
+++ b/pkg/controller/options.go
@@ -11,7 +11,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/upbound/upjet/pkg/config"
-	"github.com/upbound/upjet/pkg/controller/handler"
 	"github.com/upbound/upjet/pkg/terraform"
 )
 
@@ -39,10 +38,6 @@ type Options struct {
 
 	// ESSOptions for External Secret Stores.
 	ESSOptions *ESSOptions
-
-	// EventHandler to handle the Kubernetes events and
-	// to queue reconcile requests.
-	EventHandler *handler.EventHandler
 }
 
 // ESSOptions for External Secret Stores.

--- a/pkg/pipeline/templates/controller.go.tmpl
+++ b/pkg/pipeline/templates/controller.go.tmpl
@@ -12,6 +12,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/ratelimiter"
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	xpresource "github.com/crossplane/crossplane-runtime/pkg/resource"
+	"github.com/upbound/upjet/pkg/controller/handler"
 	tjcontroller "github.com/upbound/upjet/pkg/controller"
 	"github.com/upbound/upjet/pkg/terraform"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -35,11 +36,12 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	if o.SecretStoreConfigGVK != nil {
 		cps = append(cps, connection.NewDetailsManager(mgr.GetClient(), *o.SecretStoreConfigGVK, connection.WithTLSConfig(o.ESSOptions.TLSConfig)))
 	}
+	eventHandler := handler.NewEventHandler(handler.WithLogger(o.Logger.WithValues("gvk", {{ .TypePackageAlias }}{{ .CRD.Kind }}_GroupVersionKind)))
 	{{- if .UseAsync }}
-	ac := tjcontroller.NewAPICallbacks(mgr, xpresource.ManagedKind({{ .TypePackageAlias }}{{ .CRD.Kind }}_GroupVersionKind), tjcontroller.WithEventHandler(o.EventHandler))
+	ac := tjcontroller.NewAPICallbacks(mgr, xpresource.ManagedKind({{ .TypePackageAlias }}{{ .CRD.Kind }}_GroupVersionKind), tjcontroller.WithEventHandler(eventHandler))
 	{{- end}}
 	opts := []managed.ReconcilerOption{
-		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), o.WorkspaceStore, o.SetupFn, o.Provider.Resources["{{ .ResourceType }}"], tjcontroller.WithLogger(o.Logger), tjcontroller.WithConnectorEventHandler(o.EventHandler),
+		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), o.WorkspaceStore, o.SetupFn, o.Provider.Resources["{{ .ResourceType }}"], tjcontroller.WithLogger(o.Logger), tjcontroller.WithConnectorEventHandler(eventHandler),
 			{{- if .UseAsync }}
 			tjcontroller.WithCallbackProvider(ac),
 			{{- end}}
@@ -63,6 +65,6 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		Named(name).
 		WithOptions(o.ForControllerRuntime()).
 		WithEventFilter(xpresource.DesiredStateChanged()).
-		Watches(&{{ .TypePackageAlias }}{{ .CRD.Kind }}{}, o.EventHandler).
+		Watches(&{{ .TypePackageAlias }}{{ .CRD.Kind }}{}, eventHandler).
 		Complete(ratelimiter.NewReconciler(name, r, o.GlobalRateLimiter))
 }

--- a/pkg/pipeline/templates/setup.go.tmpl
+++ b/pkg/pipeline/templates/setup.go.tmpl
@@ -8,7 +8,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/upbound/upjet/pkg/controller"
-	"github.com/upbound/upjet/pkg/controller/handler"
 
 	{{ .Imports }}
 )
@@ -16,11 +15,6 @@ import (
 // Setup{{ .Group }} creates all controllers with the supplied logger and adds them to
 // the supplied manager.
 func Setup{{ .Group }}(mgr ctrl.Manager, o controller.Options) error {
-	// set the default event handler if the provider's main module did not
-	// set one.
-	if o.EventHandler == nil {
-		o.EventHandler = handler.NewEventHandler()
-	}
 	for _, setup := range []func(ctrl.Manager, controller.Options) error{
 		{{- range $alias := .Aliases }}
 		{{ $alias }}Setup,


### PR DESCRIPTION
<!--
Thank you for helping to improve Upjet!

Please read through https://git.io/fj2m9 if this is your first time opening a
Upjet pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Upjet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
During some load tests with `upbound/provider-aws@v0.38.0`, we've spotted a bug where a reconcile request might be requeued in a wrong workqueue. The bug manifests itself in the provider debug logs with messages similar to the following:
```
2023-08-10T14:47:56Z    DEBUG   provider-aws    Reconciling     {"controller": "managed/iam.aws.upbound.io/v1beta1, kind=rolepolicyattachment", "request": {"name":"rachel-sweeney-auth-service-default-policy-h5ck6"}}
2023-08-10T14:47:56Z    DEBUG   provider-aws    Cannot get managed resource     {"controller": "managed/iam.aws.upbound.io/v1beta1, kind=rolepolicyattachment", "request": {"name":"rachel-sweeney-auth-service-default-policy-h5ck6"}, "error": "RolePolicyAttachment.iam.aws.upbound.io \"rachel-sweeney-auth-service-default-policy-h5ck6\" not found"}
2023-08-10T14:48:10Z    DEBUG   provider-aws    Reconciling     {"controller": "managed/iam.aws.upbound.io/v1beta1, kind=policy", "request": {"name":"rachel-sweeney-auth-service-default-policy-h5ck6"}}
2023-08-10T14:48:10Z    DEBUG   provider-aws    External resource is up to date {"controller": "managed/iam.aws.upbound.io/v1beta1, kind=policy", "request": {"name":"rachel-sweeney-auth-service-default-policy-h5ck6"}, "uid": "7f8b9e51-34c4-475e-8653-53cb2adb364d", "version": "51370046", "external-name": "rachel-sweeney-auth-service-default-policy-h5ck6", "requeue-after": "2023-08-10T14:49:10Z"}
2023-08-10T14:50:04Z    DEBUG   provider-aws    Reconciling     {"controller": "managed/iam.aws.upbound.io/v1beta1, kind=policy", "request": {"name":"rachel-sweeney-auth-service-default-policy-h5ck6"}}
2023-08-10T14:50:04Z    DEBUG   provider-aws    External resource is up to date {"controller": "managed/iam.aws.upbound.io/v1beta1, kind=policy", "request": {"name":"rachel-sweeney-auth-service-default-policy-h5ck6"}, "uid": "7f8b9e51-34c4-475e-8653-53cb2adb364d", "version": "51370046", "external-name": "rachel-sweeney-auth-service-default-policy-h5ck6", "requeue-after": "2023-08-10T14:51:04Z"}
```

The issue here is that the reconciler is attempting to observe a resource using a wrong kind and this results in a not-found error. The root cause of the issue is that we are unintentionally sharing the event handlers across all the reconcilers in a given API group. The fix is to have separate event handlers per GVK.

This bug causes the reconciler to do unnecessary work. Reconciliation opportunities are lost for a given (GVK,name) pair because another pair is observed. This bug does not affect the periodic reconciles done at each poll period and hence an affected resource is eventually successfully reconciled. But successful reconciliation needs more attempts. This results in, for instance, increased TTR, and similar.

This PR also improves some debug logging that proved to be useful in interpreting the results we observed in the load tests. We are also planning to expose some further custom metrics reporting these measurements to improve monitoring.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Performed load tests with 3000 MRs. Based on just one observation, initially it took ~2h for a resource affected by this bug to transition to the ready state under heavy load (99% total CPU (over all available CPU) utilization). With the fix, it took ~1857 s on average for 23 tries (experiments) with a single resource on top of 3000 MRs.

[contribution process]: https://git.io/fj2m9
