### PR TITLE
remove overwrite from initProvider-forProvider merge

### DIFF
--- a/pkg/terraform/files_test.go
+++ b/pkg/terraform/files_test.go
@@ -424,22 +424,25 @@ func TestWriteMainTF(t *testing.T) {
 						"param": "paramval",
 						"array": []any{
 							map[string]any{
-								"other": "val",
+								"other": "val1",
 							},
 						},
 						"map": map[string]any{
-							"ignoredKey": "val",
+							"mapKey": "val2",
 						},
 					},
 						InitParameters: map[string]any{
+							"param":   "should-not-overwrite",
 							"ignored": "ignoredval",
 							"array": []any{
 								map[string]any{
-									"key": "val",
+									"key":   "val3",
+									"other": "should-not-overwrite",
 								},
 							},
 							"map": map[string]any{
-								"mapKey": "val",
+								"mapKey":     "should-not-overwrite",
+								"ignoredKey": "should-be-ignored",
 							},
 						}},
 					Observable: fake.Observable{Observation: map[string]any{
@@ -461,7 +464,7 @@ func TestWriteMainTF(t *testing.T) {
 				}(),
 			},
 			want: want{
-				maintf: `{"provider":{"provider-test":null},"resource":{"":{"":{"array":[{"key":"val","other":"val"}],"ignored":"ignoredval","lifecycle":{"ignore_changes":["array[0].key","ignored","map[\"mapKey\"]"],"prevent_destroy":true},"map":{"ignoredKey":"val","mapKey":"val"},"name":"some-id","param":"paramval"}}},"terraform":{"required_providers":{"provider-test":{"source":"hashicorp/provider-test","version":"1.2.3"}}}}`,
+				maintf: `{"provider":{"provider-test":null},"resource":{"":{"":{"array":[{"key":"val3","other":"val1"}],"ignored":"ignoredval","lifecycle":{"ignore_changes":["array[0].key","ignored","map[\"ignoredKey\"]"],"prevent_destroy":true},"map":{"ignoredKey":"should-be-ignored","mapKey":"val2"},"name":"some-id","param":"paramval"}}},"terraform":{"required_providers":{"provider-test":{"source":"hashicorp/provider-test","version":"1.2.3"}}}}`,
 			},
 		},
 	}


### PR DESCRIPTION
<!--
Thank you for helping to improve Upjet!

Please read through https://git.io/fj2m9 if this is your first time opening a
Upjet pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

This resolves a TODO left from https://github.com/upbound/upjet/pull/237 where during the `spec.initProvider` to `spec.forProvider` merge the fields in `spec.initProvider` would overwrite the `spec.forProvider` ones, instead
of skipping those fields. 

Although we would expect and suggest not to set the same fields for both, it still good to fix this behaviour.

To merge the 2, we used [mergo](https://github.com/darccio/mergo), with the option SliceDeepCopy to merge
the slices from initProvider to forProvider.

```go
err = mergo.Merge(&params, initParams, mergo.WithSliceDeepCopy)
```

Looking deeper, we can see the the `mergo.WithSliceDeepCopy` also [sets the Overwrite to true](https://github.com/darccio/mergo/blob/1475161b8f00ae26a13f5baa3debc0e3d9a85582/merge.go#L368-L372)

So simply setting the overwrite to false does the trick.
```go
err = mergo.Merge(&params, initParams, mergo.WithSliceDeepCopy, func(c *mergo.Config) {
	c.Overwrite = false
})
```
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Upjet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #240 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [] ~Added `backport release-x.y` labels to auto-backport this PR if necessary.~

### How has this code been tested

Extended the unit test to test for overwrites.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
