### PR TITLE
Add the `inUse` count to SharedProviderScheduler log statements

### DIFF
--- a/pkg/terraform/provider_scheduler.go
+++ b/pkg/terraform/provider_scheduler.go
@@ -164,14 +164,14 @@ func (s *SharedProviderScheduler) Start(h ProviderHandle) (InUse, string, error)
 			return nil, "", tferrors.NewRetryScheduleError(r.invocationCount, s.ttl)
 		}
 
-		logger.Debug("Reusing the provider runner", "invocationCount", r.invocationCount)
+		logger.Debug("Reusing the provider runner", "invocationCount", r.invocationCount, "inUse", r.inUse)
 		rc, err := r.Start()
 		return &providerInUse{
 			scheduler: s,
 			handle:    h,
 		}, rc, errors.Wrapf(err, "cannot use already started provider with handle: %s", h)
 	case r != nil:
-		logger.Debug("The provider runner has expired. Attempting to stop...", "invocationCount", r.invocationCount)
+		logger.Debug("The provider runner has expired. Attempting to stop...", "invocationCount", r.invocationCount, "inUse", r.inUse)
 		if err := r.Stop(); err != nil {
 			return nil, "", errors.Wrapf(err, "cannot schedule a new shared provider for handle: %s", h)
 		}


### PR DESCRIPTION
### Description of your changes

This exposes the `inUse` count in debug log statements. 

We upgraded upbound-provider-gcp to v0.35.0 recently, and saw a number of occasions where it got completely stuck because the provider runner had expired but wasn't being recreated. I suspect this is because the `inUse` count hadn't been decremented at some point, but we weren't able to tell; this change is the first step towards debugging that.

This is related to https://github.com/upbound/provider-gcp/issues/348

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Ran unit tests

[contribution process]: https://git.io/fj2m9
