### PR TITLE
Queue a reconcile request after marking the resource as ready

### DIFF
--- a/pkg/controller/external_test.go
+++ b/pkg/controller/external_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
+	"github.com/crossplane/crossplane-runtime/pkg/logging"
 	xpmeta "github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	xpresource "github.com/crossplane/crossplane-runtime/pkg/resource"
@@ -601,7 +602,7 @@ func TestObserve(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			e := &external{workspace: tc.w, config: config.DefaultResource("upjet_resource", nil, nil), kube: tc.args.client}
+			e := &external{workspace: tc.w, config: config.DefaultResource("upjet_resource", nil, nil), kube: tc.args.client, logger: logging.NewNopLogger()}
 			observation, err := e.Observe(context.TODO(), tc.args.obj)
 			if diff := cmp.Diff(tc.want.obs, observation); diff != "" {
 				t.Errorf("\n%s\nObserve(...): -want observation, +got observation:\n%s", tc.reason, diff)


### PR DESCRIPTION
<!--
Thank you for helping to improve Upjet!

Please read through https://git.io/fj2m9 if this is your first time opening a
Upjet pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Upjet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
With this PR, right after marking a managed resource as ready (adding the `Ready=True` status condition), we queue a reconcile request because the status updates will no longer trigger a reconciliation and there may be a need for a subsequent reconcile for late-initialization. Currently, we need to wait for the poll interval after marking a resource as ready before it's late-initialized as we prioritize marking a resource as ready over late-initializing it unlike the community providers (this is at least the case for the community AWS provider). 

We are also planning to change this behavior and simplify the logic implemented [here](https://github.com/upbound/upjet/blob/e620c6228964310a1535e6d55030b85bfaac8b61/pkg/controller/external.go#L295) in a future PR.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Please see the comment [below](https://github.com/upbound/upjet/pull/262#pullrequestreview-1591054002).


[contribution process]: https://git.io/fj2m9
