### PR TITLE
Adding a PlanGeneratorOption for excluding Kubernetes scenario based steps from Filesystem scenario

### DIFF
--- a/pkg/migration/api_steps.go
+++ b/pkg/migration/api_steps.go
@@ -50,6 +50,19 @@ func getAPIMigrationSteps() []step {
 	return steps
 }
 
+func getAPIMigrationStepsFileSystemMode() []step {
+	return []step{
+		stepCreateNewManaged,
+		stepNewCompositions,
+		stepEditComposites,
+		stepEditClaims,
+		stepStartManaged,
+		stepStartComposites,
+		// this must be the last step
+		stepAPIEnd,
+	}
+}
+
 func (pg *PlanGenerator) addStepsForManagedResource(u *UnstructuredWithMetadata) error {
 	if u.Metadata.Category != CategoryManaged {
 		if _, ok, err := toManagedResource(pg.registry.scheme, u.Object); err != nil || !ok {

--- a/pkg/migration/plan_generator.go
+++ b/pkg/migration/plan_generator.go
@@ -109,6 +109,12 @@ func WithEnableConfigurationMigrationSteps() PlanGeneratorOption {
 	}
 }
 
+func WithEnableOnlyFileSystemAPISteps() PlanGeneratorOption {
+	return func(pg *PlanGenerator) {
+		pg.enabledSteps = getAPIMigrationStepsFileSystemMode()
+	}
+}
+
 type sources struct {
 	backends []Source
 	i        int

--- a/pkg/migration/plan_steps.go
+++ b/pkg/migration/plan_steps.go
@@ -78,9 +78,29 @@ func (pg *PlanGenerator) commitSteps() {
 		keys = append(keys, s)
 	}
 	sort.Strings(keys)
-	for _, s := range keys {
-		AddManualExecution(pg.Plan.Spec.stepMap[s])
-		pg.Plan.Spec.Steps = append(pg.Plan.Spec.Steps, *pg.Plan.Spec.stepMap[s])
+
+	addManualExecution := true
+	switch t := pg.source.(type) {
+	case *sources:
+		for _, source := range t.backends {
+			if _, ok := source.(*FileSystemSource); ok {
+				addManualExecution = false
+				break
+			}
+		}
+	case *FileSystemSource:
+		addManualExecution = false
+	}
+
+	if addManualExecution {
+		for _, s := range keys {
+			AddManualExecution(pg.Plan.Spec.stepMap[s])
+			pg.Plan.Spec.Steps = append(pg.Plan.Spec.Steps, *pg.Plan.Spec.stepMap[s])
+		}
+	} else {
+		for _, s := range keys {
+			pg.Plan.Spec.Steps = append(pg.Plan.Spec.Steps, *pg.Plan.Spec.stepMap[s])
+		}
 	}
 }
 

--- a/pkg/migration/testdata/plan/generated/migration_plan_filesystem.yaml
+++ b/pkg/migration/testdata/plan/generated/migration_plan_filesystem.yaml
@@ -1,0 +1,55 @@
+spec:
+  steps:
+    - apply:
+        files:
+          - create-new-managed/sample-vpc.vpcs.faketargetapi.yaml
+      name: create-new-managed
+      manualExecution:
+        - "kubectl apply -f create-new-managed/sample-vpc.vpcs.faketargetapi.yaml"
+      type: Apply
+
+    - apply:
+        files:
+          - new-compositions/example-migrated.compositions.apiextensions.crossplane.io.yaml
+      name: new-compositions
+      manualExecution:
+        - "kubectl apply -f new-compositions/example-migrated.compositions.apiextensions.crossplane.io.yaml"
+      type: Apply
+
+    - patch:
+        type: merge
+        files:
+          - edit-composites/my-resource-dwjgh.xmyresources.test.com.yaml
+      name: edit-composites
+      manualExecution:
+        - "kubectl patch --type='merge' -f edit-composites/my-resource-dwjgh.xmyresources.test.com.yaml --patch-file edit-composites/my-resource-dwjgh.xmyresources.test.com.yaml"
+      type: Patch
+
+    - patch:
+        type: merge
+        files:
+          - edit-claims/my-resource.myresources.test.com.yaml
+      name: edit-claims
+      manualExecution:
+        - "kubectl patch --type='merge' -f edit-claims/my-resource.myresources.test.com.yaml --patch-file edit-claims/my-resource.myresources.test.com.yaml"
+      type: Patch
+
+    - patch:
+        type: merge
+        files:
+          - start-managed/sample-vpc.vpcs.faketargetapi.yaml
+      name: start-managed
+      manualExecution:
+        - "kubectl patch --type='merge' -f start-managed/sample-vpc.vpcs.faketargetapi.yaml --patch-file start-managed/sample-vpc.vpcs.faketargetapi.yaml"
+      type: Patch
+
+    - patch:
+        type: merge
+        files:
+          - start-composites/my-resource-dwjgh.xmyresources.test.com.yaml
+      name: start-composites
+      manualExecution:
+        - "kubectl patch --type='merge' -f start-composites/my-resource-dwjgh.xmyresources.test.com.yaml --patch-file start-composites/my-resource-dwjgh.xmyresources.test.com.yaml"
+      type: Patch
+
+version: 0.1.0


### PR DESCRIPTION
### Description of your changes

This PR:

- Adds a PlanGeneratorOption for excluding Kubernetes scenario based steps from Filesystem scenario
- Removes manual execution fields from plan for Filesystem source
- Adds critical annotations to the ignore list of CopyInto function

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Tested in the migrator template

[contribution process]: https://git.io/fj2m9
