### PR TITLE
Adding ResourcePreProcessor interface

### DIFF
--- a/pkg/migration/interfaces.go
+++ b/pkg/migration/interfaces.go
@@ -162,6 +162,16 @@ type UnstructuredPreProcessor interface {
 	PreProcess(u UnstructuredWithMetadata) error
 }
 
+// ManagedPreProcessor allows manifests read by the Source
+// to be pre-processed before the converters are run.
+// These pre-processors will work for GVKs that have ResourceConverter
+// registered.
+type ManagedPreProcessor interface {
+	// ResourcePreProcessor is called for a manifest read by the Source
+	// before any converters are run.
+	ResourcePreProcessor(mg resource.Managed) error
+}
+
 // CategoricalConverter is a converter that converts resources of a given
 // Category. Because it receives an unstructured argument, it should be
 // used for implementing generic conversion functions acting on a specific

--- a/pkg/migration/plan_generator.go
+++ b/pkg/migration/plan_generator.go
@@ -407,6 +407,13 @@ func (pg *PlanGenerator) convertResource(o UnstructuredWithMetadata, composition
 	if err != nil {
 		return nil, false, errors.Wrap(err, errResourceMigrate)
 	}
+	if pg.registry.resourcePreProcessors != nil {
+		for _, pp := range pg.registry.resourcePreProcessors {
+			if err = pp.ResourcePreProcessor(mg); err != nil {
+				return nil, false, errors.Wrap(err, errResourceMigrate)
+			}
+		}
+	}
 	resources, err := conv.Resource(mg)
 	if err != nil {
 		return nil, false, errors.Wrap(err, errResourceMigrate)

--- a/pkg/migration/registry.go
+++ b/pkg/migration/registry.go
@@ -97,6 +97,7 @@ type packageLockConverter struct {
 // runtime.Scheme with which the corresponding types are registered.
 type Registry struct {
 	unstructuredPreProcessors      map[Category][]UnstructuredPreProcessor
+	resourcePreProcessors          []ManagedPreProcessor
 	resourceConverters             map[schema.GroupVersionKind]ResourceConverter
 	templateConverters             map[schema.GroupVersionKind]ComposedTemplateConverter
 	patchSetConverters             []patchSetConverter
@@ -535,4 +536,17 @@ func (pp PreProcessor) PreProcess(u UnstructuredWithMetadata) error {
 		return nil
 	}
 	return pp(u)
+}
+
+func (r *Registry) RegisterResourcePreProcessor(pp ManagedPreProcessor) {
+	r.resourcePreProcessors = append(r.resourcePreProcessors, pp)
+}
+
+type ResourcePreProcessor func(mg resource.Managed) error
+
+func (pp ResourcePreProcessor) ResourcePreProcessor(mg resource.Managed) error {
+	if pp == nil {
+		return nil
+	}
+	return pp(mg)
 }


### PR DESCRIPTION
### Description of your changes

This PR adds ResourcePreProcessor interface that allows manifests read by the Source to be pre-processed before the converters are run. These pre-processors will work for GVKs that have ResourceConverter registered.

Related https://github.com/upbound/extensions-migration/issues/30

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Tested against AWS VPC resource.

[contribution process]: https://git.io/fj2m9
