### PR TITLE
Don't scrape empty files

### DIFF
--- a/pkg/registry/meta.go
+++ b/pkg/registry/meta.go
@@ -498,6 +498,16 @@ func (pm *ProviderMetadata) ScrapeRepo(config *ScrapeConfiguration) error {
 			return nil
 		}
 		r := &Resource{}
+		// don't scrape if file is empty
+		filename := filepath.Clean(path)
+		b, err := os.ReadFile(filename)
+		if err != nil {
+			return errors.Wrap(err, "failed to read markdown file")
+		}
+		if len(b) == 1 {
+			fmt.Printf("skipping empty file: %s\n", filename)
+			return nil
+		}
 		if err := r.scrape(path, config); err != nil {
 			return errors.Wrapf(err, "failed to scrape resource metadata from path: %s", path)
 		}


### PR DESCRIPTION
<!--
Thank you for helping to improve Upjet!

Please read through https://git.io/fj2m9 if this is your first time opening a
Upjet pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Some providers like [Fastly](https://github.com/fastly/terraform-provider-fastly) have empty files in their docs. This PR modifies the scraper so that it won't fail trying to read empty files 

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

The scraper doesn't fail when running

`go run cmd/scraper/main.go -n fastly/fastly -r .work/fastly/fastly/docs/resources -o config/provider-metadata.yaml`

(assuming the `fastly/fastly` repo content is already available at `./.work`)

[contribution process]: https://git.io/fj2m9
