### PR TITLE
CEL rules extension

### DIFF
--- a/pkg/types/builder.go
+++ b/pkg/types/builder.go
@@ -465,7 +465,7 @@ func sanitizePath(p string) string {
 }
 
 func constructCELPath(celPath []string) string {
-	var currentPath []string
+	currentPath := make([]string, 0, len(celPath))
 	// Go through the list of fields, and if a wildcard is encountered,
 	// it means that the previous field is a list, so we add "[0]" to the path.
 	// This is not ideal, but as there is no "list[*]" in CEL, we are at
@@ -493,7 +493,7 @@ func constructCELRules(celPath []string, isInit bool) *celRule {
 		return &celRule{}
 	}
 	var rule []string
-	var currentPath []string
+	currentPath := make([]string, 0, len(celPath))
 
 	// construct forProvider rule.
 	// If the field is a wildcard, it means that the previous field is a list,

--- a/pkg/types/builder_test.go
+++ b/pkg/types/builder_test.go
@@ -250,7 +250,7 @@ func TestBuild(t *testing.T) {
 				},
 			},
 			want: want{
-				forProvider: `type example.Parameters struct{Enable *bool "json:\"enable,omitempty\" tf:\"enable,omitempty\""; ID *int64 "json:\"id,omitempty\" tf:\"id,omitempty\""; Name *string "json:\"name,omitempty\" tf:\"name,omitempty\""}`,
+				forProvider: `type example.Parameters struct{Enable *bool "json:\"enable,omitempty\" tf:\"enable,omitempty\""; ID *int64 "json:\"id\" tf:\"id,omitempty\""; Name *string "json:\"name\" tf:\"name,omitempty\""}`,
 				atProvider:  `type example.Observation struct{Config *string "json:\"config,omitempty\" tf:\"config,omitempty\""; Enable *bool "json:\"enable,omitempty\" tf:\"enable,omitempty\""; ID *int64 "json:\"id,omitempty\" tf:\"id,omitempty\""; Name *string "json:\"name,omitempty\" tf:\"name,omitempty\""; Value *float64 "json:\"value,omitempty\" tf:\"value,omitempty\""}`,
 				validationRules: `
 // +kubebuilder:validation:XValidation:rule="!('*' in self.managementPolicies || 'Create' in self.managementPolicies || 'Update' in self.managementPolicies) || has(self.forProvider.id) || has(self.initProvider.id)",message="id is a required parameter"
@@ -286,7 +286,7 @@ func TestBuild(t *testing.T) {
 				},
 			},
 			want: want{
-				forProvider: `type example.Parameters struct{List []*string "json:\"list,omitempty\" tf:\"list,omitempty\""; ResourceIn map[string]example.ResourceInParameters "json:\"resourceIn,omitempty\" tf:\"resource_in,omitempty\""}`,
+				forProvider: `type example.Parameters struct{List []*string "json:\"list\" tf:\"list,omitempty\""; ResourceIn map[string]example.ResourceInParameters "json:\"resourceIn\" tf:\"resource_in,omitempty\""}`,
 				atProvider:  `type example.Observation struct{List []*string "json:\"list,omitempty\" tf:\"list,omitempty\""; ResourceIn map[string]example.ResourceInParameters "json:\"resourceIn,omitempty\" tf:\"resource_in,omitempty\""; ResourceOut map[string]example.ResourceOutObservation "json:\"resourceOut,omitempty\" tf:\"resource_out,omitempty\""}`,
 				validationRules: `
 // +kubebuilder:validation:XValidation:rule="!('*' in self.managementPolicies || 'Create' in self.managementPolicies || 'Update' in self.managementPolicies) || has(self.forProvider.list) || has(self.initProvider.list)",message="list is a required parameter"
@@ -364,7 +364,7 @@ func TestBuild(t *testing.T) {
 				},
 			},
 			want: want{
-				forProvider: `type example.Parameters struct{Name *string "json:\"name,omitempty\" tf:\"name,omitempty\""; ReferenceID *string "json:\"referenceId,omitempty\" tf:\"reference_id,omitempty\""; ExternalResourceID *github.com/crossplane/crossplane-runtime/apis/common/v1.Reference "json:\"externalResourceId,omitempty\" tf:\"-\""; ReferenceIDSelector *github.com/crossplane/crossplane-runtime/apis/common/v1.Selector "json:\"referenceIdSelector,omitempty\" tf:\"-\""}`,
+				forProvider: `type example.Parameters struct{Name *string "json:\"name\" tf:\"name,omitempty\""; ReferenceID *string "json:\"referenceId,omitempty\" tf:\"reference_id,omitempty\""; ExternalResourceID *github.com/crossplane/crossplane-runtime/apis/common/v1.Reference "json:\"externalResourceId,omitempty\" tf:\"-\""; ReferenceIDSelector *github.com/crossplane/crossplane-runtime/apis/common/v1.Selector "json:\"referenceIdSelector,omitempty\" tf:\"-\""}`,
 				atProvider:  `type example.Observation struct{Name *string "json:\"name,omitempty\" tf:\"name,omitempty\""; ReferenceID *string "json:\"referenceId,omitempty\" tf:\"reference_id,omitempty\""}`,
 				validationRules: `
 // +kubebuilder:validation:XValidation:rule="!('*' in self.managementPolicies || 'Create' in self.managementPolicies || 'Update' in self.managementPolicies) || has(self.forProvider.name) || has(self.initProvider.name)",message="name is a required parameter"`,
@@ -407,11 +407,44 @@ func TestBuild(t *testing.T) {
 				},
 			},
 			want: want{
-				forProvider: `type example.Parameters struct{Name *string "json:\"name,omitempty\" tf:\"name,omitempty\""; Namespace *string "json:\"namespace,omitempty\" tf:\"namespace,omitempty\""}`,
+				forProvider: `type example.Parameters struct{Name *string "json:\"name\" tf:\"name,omitempty\""; Namespace *string "json:\"namespace\" tf:\"namespace,omitempty\""}`,
 				atProvider:  `type example.Observation struct{Name *string "json:\"name,omitempty\" tf:\"name,omitempty\""; Namespace *string "json:\"namespace,omitempty\" tf:\"namespace,omitempty\""}`,
 				validationRules: `
 // +kubebuilder:validation:XValidation:rule="!('*' in self.managementPolicies || 'Create' in self.managementPolicies || 'Update' in self.managementPolicies) || has(self.forProvider.name) || has(self.initProvider.name)",message="name is a required parameter"
-// +kubebuilder:validation:XValidation:rule="!('*' in self.managementPolicies || 'Create' in self.managementPolicies || 'Update' in self.managementPolicies) || has(self.forProvider.__namespace__) || has(self.initProvider.__namespace__)",message="namespace is a required parameter"`,
+// +kubebuilder:validation:XValidation:rule="!('*' in self.managementPolicies || 'Create' in self.managementPolicies || 'Update' in self.managementPolicies) || has(self.forProvider.__namespace__) || has(self.initProvider.__namespace__)",message="__namespace__ is a required parameter"`,
+			},
+		},
+		"Nested_Required_Fields": {
+			args: args{
+				cfg: &config.Resource{
+					TerraformResource: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"nested": {
+								Type:     schema.TypeList,
+								Required: true,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"nested_required": {
+											Type:     schema.TypeString,
+											Required: true,
+										},
+										"nested_optional": {
+											Type:     schema.TypeString,
+											Optional: true,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: want{
+				forProvider: `type example.Parameters struct{Nested []example.NestedParameters "json:\"nested\" tf:\"nested,omitempty\""}`,
+				atProvider:  `type example.Observation struct{Nested []example.NestedObservation "json:\"nested,omitempty\" tf:\"nested,omitempty\""}`,
+				validationRules: `
+// +kubebuilder:validation:XValidation:rule="!('*' in self.managementPolicies || 'Create' in self.managementPolicies || 'Update' in self.managementPolicies) || !has(self.forProvider.nested) || has(self.forProvider.nested[0].nestedRequired) || has(self.initProvider.nested[0].nestedRequired)",message="nested[0].nestedRequired is a required parameter"
+// +kubebuilder:validation:XValidation:rule="!('*' in self.managementPolicies || 'Create' in self.managementPolicies || 'Update' in self.managementPolicies) || has(self.forProvider.nested) || has(self.initProvider.nested)",message="nested is a required parameter"`,
 			},
 		},
 	}
@@ -435,6 +468,129 @@ func TestBuild(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.want.validationRules, g.ValidationRules); diff != "" {
 				t.Fatalf("Build(...): -want validationRules, +got validationRules: %s", diff)
+			}
+		})
+	}
+}
+
+func TestConstructCELRule(t *testing.T) {
+	type args struct {
+		celPath []string
+		isInit  bool
+	}
+	type want struct {
+		celRule *celRule
+	}
+	cases := map[string]struct {
+		args
+		want
+	}{
+		"EmptyCELPath": {
+			args: args{
+				celPath: []string{},
+				isInit:  true,
+			},
+			want: want{
+				celRule: &celRule{},
+			},
+		},
+		"SimpleCELPath": {
+			args: args{
+				celPath: []string{"required"},
+				isInit:  true,
+			},
+			want: want{
+				celRule: newCelRule(
+					"has(self.forProvider.required)",
+					"has(self.initProvider.required)",
+					"required"),
+			},
+		},
+		"SimpleNoInitCELPath": {
+			args: args{
+				celPath: []string{"required"},
+				isInit:  false,
+			},
+			want: want{
+				celRule: newCelRule(
+					"has(self.forProvider.required)",
+					"",
+					"required"),
+			},
+		},
+		"NestedCELPathMap": {
+			args: args{
+				celPath: []string{"required", "nested"},
+				isInit:  true,
+			},
+			want: want{
+				celRule: newCelRule(
+					"has(self.forProvider.required.nested)",
+					"has(self.initProvider.required.nested)",
+					"required.nested"),
+			},
+		},
+		"NestedCELPathList": {
+			args: args{
+				celPath: []string{"required", "*", "nested"},
+				isInit:  true,
+			},
+			want: want{
+				celRule: newCelRule(
+					"!has(self.forProvider.required) || has(self.forProvider.required[0].nested)",
+					"has(self.initProvider.required[0].nested)",
+					"required[0].nested"),
+			},
+		},
+		"DeepNestedCELPathList": {
+			args: args{
+				celPath: []string{"required", "*", "nested", "*", "deepNested", "*", "evenDeeperNested"},
+				isInit:  true,
+			},
+			want: want{
+				celRule: newCelRule(
+					"!has(self.forProvider.required) || !has(self.forProvider.required[0].nested) || !has(self.forProvider.required[0].nested[0].deepNested) || has(self.forProvider.required[0].nested[0].deepNested[0].evenDeeperNested)",
+					"has(self.initProvider.required[0].nested[0].deepNested[0].evenDeeperNested)",
+					"required[0].nested[0].deepNested[0].evenDeeperNested"),
+			},
+		},
+		"NestedCELPathListEndInWildcard": {
+			args: args{
+				celPath: []string{"required", "*", "nested", "*"},
+				isInit:  true,
+			},
+			want: want{
+				celRule: newCelRule(
+					"!has(self.forProvider.required) || has(self.forProvider.required[0].nested)",
+					"has(self.initProvider.required[0].nested)",
+					"required[0].nested"),
+			},
+		},
+		"NestedCELPathListReservedKeyword": {
+			args: args{
+				celPath: []string{"namespace", "*", "nested"},
+				isInit:  true,
+			},
+			want: want{
+				celRule: newCelRule(
+					"!has(self.forProvider.__namespace__) || has(self.forProvider.__namespace__[0].nested)",
+					"has(self.initProvider.__namespace__[0].nested)",
+					"__namespace__[0].nested"),
+			},
+		},
+	}
+	for n, tc := range cases {
+		t.Run(n, func(t *testing.T) {
+			res := constructCELRules(tc.args.celPath, tc.isInit)
+
+			if diff := cmp.Diff(tc.want.celRule.rule, res.rule); diff != "" {
+				t.Fatalf("Build(...): -want rule, +got rule: %s", diff)
+			}
+			if diff := cmp.Diff(tc.want.celRule.path, res.path); diff != "" {
+				t.Fatalf("Build(...): -want path, +got path: %s", diff)
+			}
+			if diff := cmp.Diff(tc.want.celRule.initProviderRule, res.initProviderRule); diff != "" {
+				t.Fatalf("Build(...): -want initProviderRule, +got initProviderRule: %s", diff)
 			}
 		})
 	}

--- a/pkg/types/field.go
+++ b/pkg/types/field.go
@@ -132,8 +132,10 @@ func NewField(g *Builder, cfg *config.Resource, r *resource, sch *schema.Schema,
 	f.CanonicalPaths = append(names[1:], f.Name.Camel) // nolint:gocritic
 	// CEL paths, e.g. {"lifecycleRule", "*", "transition", "*", "days"}
 	if f.Schema.Sensitive {
+		// nolint:gocritic
 		f.CELPaths = append(celPath, f.Name.LowerCamelComputed+sfx)
 	} else {
+		// nolint:gocritic
 		f.CELPaths = append(celPath, f.Name.LowerCamelComputed)
 	}
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Upjet!

Please read through https://git.io/fj2m9 if this is your first time opening a
Upjet pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

**Disclaimer** :warning: 
I am not entirely happy with this solution and am wondering if we should merge this. Putting it out for discussion and explaining my thought process below

### Intro
In https://github.com/upbound/upjet/pull/237 we made all non-init fields optional, so that they
can be set either in `spec.forProvider` or `spec.initProvider`. For top level fields, we replaced the "required" validation with
CEL rules. Such as:

```yaml
// +kubebuilder:validation:XValidation:rule="!('*' in self.managementPolicies || 'Create' in self.managementPolicies || 'Update' in self.managementPolicies) || has(self.forProvider.title) || has(self.initProvider.title)",message="title is a required parameter"
```

But we didn't have a solution for the nested fields. So the purpose of this PR is to add CEL validation for nested fields that should be required.

This proved to be tricky due to 2 factors:
- how we are generating nested fields based on Terraform schemas
- [CEL language specification ](https://github.com/google/cel-spec/blob/master/doc/langdef.md)

Starting this task I had expected to generate something like:

```yaml
... has(self.forProvider.someMap.nestedField) || ...
OR
... has(self.forProvider.someList[*].nestedField) || ...
```
But I was very wrong :cold_sweat: .

### Problem explanation
Firstly, we generate almost every nested struct as an array. Even though the resource expects and needs only one element of that array. I think its due to how terraform schemas are translated into our types, as they mark all of the nested structs as lists of nested structs. I didn't go too deep into this as it's highly unlikely that we would make some changes there and break our API. 

Example from upbound/provider-gcp Cluster:

```go
	// Per-cluster configuration of Node Auto-Provisioning with Cluster Autoscaler to
	// automatically adjust the size of the cluster and create/delete node pools based
	// on the current needs of the cluster's workload. See the
	// guide to using Node Auto-Provisioning
	// for more details. Structure is documented below.
	// +kubebuilder:validation:Optional
	ClusterAutoscaling []ClusterAutoscalingParameters `json:"clusterAutoscaling,omitempty" tf:"cluster_autoscaling,omitempty"`
	
...
	type ClusterAutoscalingParameters struct {

	// Contains defaults for a node pool created by NAP. A subset of fields also apply to
	// GKE Autopilot clusters.
	// Structure is documented below.
	// +kubebuilder:validation:Optional
	AutoProvisioningDefaults []AutoProvisioningDefaultsParameters `json:"autoProvisioningDefaults,omitempty" tf:"auto_provisioning_defaults,omitempty"`

	// Whether node auto-provisioning is enabled. Must be supplied for GKE Standard clusters, true is implied
	// for autopilot clusters. Resource limits for cpu and memory must be defined to enable node auto-provisioning for GKE Standard.
	// +kubebuilder:validation:Optional
	Enabled *bool `json:"enabled,omitempty" tf:"enabled,omitempty"`
...

```

Secondly, it is how CEL works:
- we need to be mindful of the [scope](https://github.com/google/cel-spec/blob/master/doc/langdef.md#name-resolution)
- wildcards don't work

### Scope
For the scope, it basically means that as we want to reach both `forProvider` and `initProvider`, the CEL rule has to be defined on `spec`. We cannot define a rule in a nested field as it wont have access to `initProvider` and vice-versa. Otherwise this would be very handy and we wouldn't have a problem with field selection as we could just set the rule on the nested struct in question.

### Field selection
On the other hand, we have the problem of how to actually get through to the field we want to check if it is set. There are multiple ways.

Lets imagine we have the following resource:
```yaml
spec:
  forProvider:
    someList:
    - reqField: "I am set"
      nonReqField: "I just chill here"
```
The CEL rule can look like this if we want to check just if the first element exists. For most cases this is ok as we expect only one element. For those that are truly lists we miss
```yaml
has(self.forProvider.someList[0].reqField) || has(self.initProvider.someList[0].reqField)
```

CEL also provides an `all`, `exists`, `exists_one` macros that could be helpful:
```yaml
self.forProvider.someList.all(e, has(e.reqField)) || self.initProvider.someList.all(e, has(e.reqField)) 
```
The problem here is that the check will not work well with true lists, as we could have some elements in initProvider, and some in forProvider, which is narrow edge case, but still worth to keep in mind. If we use `exists` we come back to a similar solution as using `[0]`.
Example where all wont work well.
```yaml
spec:
  initProvider:
    someList:
    - additionalField: "just an init field"
    - reqField: "I am set"
      nonReqField: "I just chill here"
  forProvider:
    someList:
    - reqField: "I am set"
      nonReqField: "I just chill here"
    - additionalField: "my required field is set in initProvider"
```

So lets say that we use the solution with `[0]`:
```yaml
has(self.forProvider.someList[0].reqField) || has(self.initProvider.someList[0].reqField)
```
What if `someList` is optional? The field `reqField` is only required if `someList` actually exists. With the above rule, we would force users to use `someList`. Thats why we could add:
```yaml
!has(self.forProvider.someList) || has(self.forProvider.someList[0].reqField) || has(self.initProvider.someList[0].reqField)
``` 

And as resources have required fields few levels deep, we can get things like this(example is from GCP Provider AccessLevel):
```yaml
!(''*'' in self.managementPolicies || ''Create'' in self.managementPolicies
                || ''Update'' in self.managementPolicies) || !has(self.forProvider.basic)
                || !has(self.forProvider.basic[0].conditions) || !has(self.forProvider.basic[0].conditions[0].devicePolicy)
                || !has(self.forProvider.basic[0].conditions[0].devicePolicy[0].osConstraints)
                || has(self.forProvider.basic[0].conditions[0].devicePolicy[0].osConstraints[0].osType)
                || has(self.initProvider.basic[0].conditions[0].devicePolicy[0].osConstraints[0].osType)
```
which becomes unreadable, but works. 

As I said in the beginning, not sure if we should include this. Maybe somebody will see a better solution. The current PR implements the above. 

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Upjet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #":

-->
Fixes #239 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Tested with https://github.com/upbound/provider-gcp/. Ran `make generate` with my `upjet`. Created the `/apis/accesscontextmanager/v1beta1/zz_accesslevel_types.go`  CRD in a local kind cluster and tested with a few examples:

Resulting CEL rules:
```yaml
x-kubernetes-validations:
            - message: basic[0].conditions[0].devicePolicy[0].osConstraints[0].osType
                is a required parameter
              rule: '!(''*'' in self.managementPolicies || ''Create'' in self.managementPolicies
                || ''Update'' in self.managementPolicies) || !has(self.forProvider.basic)
                || !has(self.forProvider.basic[0].conditions) || !has(self.forProvider.basic[0].conditions[0].devicePolicy)
                || !has(self.forProvider.basic[0].conditions[0].devicePolicy[0].osConstraints)
                || has(self.forProvider.basic[0].conditions[0].devicePolicy[0].osConstraints[0].osType)
                || has(self.initProvider.basic[0].conditions[0].devicePolicy[0].osConstraints[0].osType)'
            - message: basic[0].conditions is a required parameter
              rule: '!(''*'' in self.managementPolicies || ''Create'' in self.managementPolicies
                || ''Update'' in self.managementPolicies) || !has(self.forProvider.basic)
                || has(self.forProvider.basic[0].conditions) || has(self.initProvider.basic[0].conditions)'
            - message: custom[0].expr[0].expression is a required parameter
              rule: '!(''*'' in self.managementPolicies || ''Create'' in self.managementPolicies
                || ''Update'' in self.managementPolicies) || !has(self.forProvider.custom)
                || !has(self.forProvider.custom[0].expr) || has(self.forProvider.custom[0].expr[0].expression)
                || has(self.initProvider.custom[0].expr[0].expression)'
            - message: custom[0].expr is a required parameter
              rule: '!(''*'' in self.managementPolicies || ''Create'' in self.managementPolicies
                || ''Update'' in self.managementPolicies) || !has(self.forProvider.custom)
                || has(self.forProvider.custom[0].expr) || has(self.initProvider.custom[0].expr)'
            - message: name is a required parameter
              rule: '!(''*'' in self.managementPolicies || ''Create'' in self.managementPolicies
                || ''Update'' in self.managementPolicies) || has(self.forProvider.name)
                || has(self.initProvider.name)'
            - message: parent is a required parameter
              rule: '!(''*'' in self.managementPolicies || ''Create'' in self.managementPolicies
                || ''Update'' in self.managementPolicies) || has(self.forProvider.parent)
                || has(self.initProvider.parent)'
            - message: title is a required parameter
              rule: '!(''*'' in self.managementPolicies || ''Create'' in self.managementPolicies
                || ''Update'' in self.managementPolicies) || has(self.forProvider.ti
```

**Minimal passing validation:**

```yaml
apiVersion: accesscontextmanager.gcp.upbound.io/v1beta1
kind: AccessLevel
metadata:
  name: access-level-service-account
spec:
  forProvider:
    name: name
    parent: parent
    title: title
```
Result: PASSES
Description: contains the 3 required top level fields

**Minimal not passing validation**
```yaml
apiVersion: accesscontextmanager.gcp.upbound.io/v1beta1
kind: AccessLevel
metadata:
  name: access-level-service-account
spec:
  forProvider:
    name: name
    parent: parent
    title: title
```
Result: FAILS
Description: 
```bash
The AccessLevel "access-level-service-account" is invalid: spec: Invalid value: "object": no such key: initProvider evaluating rule: name is a required parameter
```

**Nested validation - one level**
```yaml
apiVersion: accesscontextmanager.gcp.upbound.io/v1beta1
kind: AccessLevel
metadata:
  name: access-level-service-account
spec:
  forProvider:
    basic:
    - conditions:
      - devicePolicy:
        - requireScreenLock: false
    name: name
    parent: parent
    title: title
```
Result: PASSES
Description: sets just `basic[0].conditions[0].devicePolicy[0]`. Does not go further into `osConstraints[]`


<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
