### PR TITLE
Fix of duplicate resource reading

### DIFF
--- a/pkg/migration/kubernetes.go
+++ b/pkg/migration/kubernetes.go
@@ -232,7 +232,11 @@ func (ks *KubernetesSource) getCategoryResources(c Category) error {
 }
 
 func (ks *KubernetesSource) getGVKResources(gvks []schema.GroupVersionKind, category Category) error {
+	processed := map[schema.GroupVersionKind]struct{}{}
 	for _, gvk := range gvks {
+		if _, ok := processed[gvk]; ok {
+			continue
+		}
 		m, err := ks.restMapper.RESTMapping(gvk.GroupKind(), gvk.Version)
 		if err != nil {
 			return errors.Wrapf(err, "cannot get REST mappings for GVK: %s", gvk.String())
@@ -240,6 +244,7 @@ func (ks *KubernetesSource) getGVKResources(gvks []schema.GroupVersionKind, cate
 		if err := ks.getResourcesFor(m.Resource, category); err != nil {
 			return errors.Wrapf(err, "cannot get resources for GVK: %s", gvk.String())
 		}
+		processed[gvk] = struct{}{}
 	}
 	return nil
 }


### PR DESCRIPTION
### Description of your changes

This PR fixes duplicate resource reading.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Tested against a Kubernetes and FileSystem sources

[contribution process]: https://git.io/fj2m9
