### PR TITLE
remove finalizers before deleting migrated old MRs

### DIFF
--- a/pkg/migration/plan_generator.go
+++ b/pkg/migration/plan_generator.go
@@ -54,6 +54,7 @@ const (
 	errComposedTemplateMigrate         = "failed to migrate the composed templates of the composition"
 	errResourceOutput                  = "failed to output migrated resource"
 	errResourceOrphan                  = "failed to orphan managed resource"
+	errResourceRemoveFinalizer         = "failed to remove finalizers of managed resource"
 	errCompositionOutput               = "failed to output migrated composition"
 	errCompositeOutput                 = "failed to output migrated composite"
 	errClaimOutput                     = "failed to output migrated claim"

--- a/pkg/migration/plan_generator_test.go
+++ b/pkg/migration/plan_generator_test.go
@@ -136,6 +136,7 @@ func TestGeneratePlan(t *testing.T) {
 					"pause-composites/my-resource-dwjgh.xmyresources.test.com.yaml",
 					"edit-composites/my-resource-dwjgh.xmyresources.test.com.yaml",
 					"deletion-policy-orphan/sample-vpc.vpcs.fakesourceapi.yaml",
+					"remove-finalizers/sample-vpc.vpcs.fakesourceapi.yaml",
 					"new-compositions/example-migrated.compositions.apiextensions.crossplane.io.yaml",
 					"start-composites/my-resource-dwjgh.xmyresources.test.com.yaml",
 					"create-new-managed/sample-vpc.vpcs.faketargetapi.yaml",

--- a/pkg/migration/plan_steps.go
+++ b/pkg/migration/plan_steps.go
@@ -69,7 +69,7 @@ func setExecStep(name string, s *Step) {
 	}
 }
 
-func (pg *PlanGenerator) commitSteps() {
+func (pg *PlanGenerator) commitSteps() { //nolint: gocyclo
 	if len(pg.Plan.Spec.stepMap) == 0 {
 		return
 	}

--- a/pkg/migration/plan_steps.go
+++ b/pkg/migration/plan_steps.go
@@ -84,7 +84,7 @@ func (pg *PlanGenerator) commitSteps() { //nolint: gocyclo
 	// therefore needs to be sorted according to their numeric values.
 	// otherwise, sorting the strings directly causes faulty behavior e.g "1" < "10" < "2"
 	// sorting will panic if a non-numeric step key is found in keys
-	sort.Slice(keys, func(i, j int) bool {
+	sort.SliceStable(keys, func(i, j int) bool {
 		fi, err := strconv.ParseFloat(keys[i], 64)
 		if err != nil {
 			panic(err)

--- a/pkg/migration/testdata/plan/generated/migration_plan.yaml
+++ b/pkg/migration/testdata/plan/generated/migration_plan.yaml
@@ -61,6 +61,15 @@ spec:
       - "kubectl patch --type='merge' -f deletion-policy-orphan/sample-vpc.vpcs.fakesourceapi.yaml --patch-file deletion-policy-orphan/sample-vpc.vpcs.fakesourceapi.yaml"
     type: Patch
 
+  - patch:
+      type: merge
+      files:
+        - remove-finalizers/sample-vpc.vpcs.fakesourceapi.yaml
+    name: remove-finalizers
+    manualExecution:
+      - "kubectl patch --type='merge' -f remove-finalizers/sample-vpc.vpcs.fakesourceapi.yaml --patch-file remove-finalizers/sample-vpc.vpcs.fakesourceapi.yaml"
+    type: Patch
+
   - delete:
       options:
         finalizerPolicy: Remove

--- a/pkg/migration/testdata/plan/generated/remove-finalizers/sample-vpc.vpcs.fakesourceapi.yaml
+++ b/pkg/migration/testdata/plan/generated/remove-finalizers/sample-vpc.vpcs.fakesourceapi.yaml
@@ -1,0 +1,6 @@
+apiVersion: fakesourceapi/v1alpha1
+kind: VPC
+metadata:
+  name: sample-vpc
+  finalizers: []
+


### PR DESCRIPTION
### Description of your changes

In MR API migration process, old API MRs have their reconciliation paused, new MRs with the target API is created, then the old API MRs are deleted. However, deletion gets stuck because they have a finalizer and their reconciliation operations are paused.

The MRs have single finalizer named `finalizer.managedresource.crossplane.io`, which ensures the deletion of native cloud provider resource, however in this case it is a no-op, since the deletion policy is `Orphan` and we already would like to keep the cloud provider resource since we are just migrating it.

This PR adds a new migration step for old MRs, that removes the finalizer.
Also, it fixes a bug in the sorting of the steps, when step count to be executed exceeds 10.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

- Run unit tests
- Manually tested with VPC resource

