### PR TITLE
Add jitter to reconcile delay for managed.Reconciler

### DIFF
--- a/pkg/controller/options.go
+++ b/pkg/controller/options.go
@@ -6,6 +6,7 @@ package controller
 
 import (
 	"crypto/tls"
+	"time"
 
 	"github.com/crossplane/crossplane-runtime/pkg/controller"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -38,6 +39,9 @@ type Options struct {
 
 	// ESSOptions for External Secret Stores.
 	ESSOptions *ESSOptions
+
+	// Adds jitter to reconcile latency for managed.Reconciler.
+	PollJitter time.Duration
 }
 
 // ESSOptions for External Secret Stores.

--- a/pkg/controller/options.go
+++ b/pkg/controller/options.go
@@ -40,7 +40,8 @@ type Options struct {
 	// ESSOptions for External Secret Stores.
 	ESSOptions *ESSOptions
 
-	// Adds jitter to reconcile latency for managed.Reconciler.
+	// PollJitter adds the specified jitter to the configured reconcile period
+	// of the up-to-date resources in managed.Reconciler.
 	PollJitter time.Duration
 }
 

--- a/pkg/pipeline/templates/controller.go.tmpl
+++ b/pkg/pipeline/templates/controller.go.tmpl
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
 		managed.WithPollInterval(o.PollInterval),
+		managed.WithPollJitterHook(o.PollJitter),
 	}
 	{{- if .FeaturesPackageAlias }}
 	if o.Features.Enabled({{ .FeaturesPackageAlias }}EnableAlphaManagementPolicies) {

--- a/pkg/pipeline/templates/controller.go.tmpl
+++ b/pkg/pipeline/templates/controller.go.tmpl
@@ -53,7 +53,9 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		managed.WithInitializers(initializers),
 		managed.WithConnectionPublishers(cps...),
 		managed.WithPollInterval(o.PollInterval),
-		managed.WithPollJitterHook(o.PollJitter),
+	}
+	if o.PollJitter != 0 {
+	    opts = append(opts, managed.WithPollJitterHook(o.PollJitter))
 	}
 	{{- if .FeaturesPackageAlias }}
 	if o.Features.Enabled({{ .FeaturesPackageAlias }}EnableAlphaManagementPolicies) {


### PR DESCRIPTION
### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Upjet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This PR adds the specified jitter to the configured reconcile period of the up-to-date resources in `managed.Reconciler`.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Tested via the `upbound/provider-aws` PR.
[contribution process]: https://git.io/fj2m9
