### PR TITLE
Add headers (license & generated) to zz_setup

### DIFF
--- a/pkg/pipeline/templates/setup.go.tmpl
+++ b/pkg/pipeline/templates/setup.go.tmpl
@@ -1,6 +1,6 @@
-/*
-Copyright 2021 Upbound Inc.
-*/
+{{ .Header }}
+
+{{ .GenStatement }}
 
 package controller
 


### PR DESCRIPTION
### Description of your changes

adds the generated and license (from boilerplate.go.txt) to `zz_setup.go`.
The code to set these template variables already existed: https://github.com/upbound/upjet/blob/a41bb83a48292e9bacb85bc1e409a7fe3595c9e7/pkg/pipeline/setup.go#L89-L90
This PR only updates the template to also use these values.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
evaluated with a custom boilerplate.go.txt for a custom provider.